### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ test_track_visitor.vary :name_of_split, context: 'home_page' do |v|
 end
 ```
 
-The `test_track_visitor`'s `ab` method provides a convenient way to do two-way splits. The optional second argument is used to tell `ab` which variant is the "true" variant. If no second argument is provided, the "true" variant is assumed to be `true`, which is convient for splits that have variants of `true` and `false`. `ab` can be easily used in an if statement.
+The `test_track_visitor`'s `ab` method provides a convenient way to do two-way splits. The `true_variant` option is used to tell `ab` which variant is the "true" variant. If no `true_variant` option is provided, the "true" variant is assumed to be `true`, which is convient for splits that have variants of `true` and `false`. `ab` can be easily used in an if statement.
 
 ```ruby
 # "button_color" split with "blue" and "red" variants

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ test_track_visitor.vary :name_of_split, context: 'home_page' do |v|
 end
 ```
 
-The `test_track_visitor`'s `ab` method provides a convenient way to do two-way splits. The `true_variant` option is used to tell `ab` which variant is the "true" variant. If no `true_variant` option is provided, the "true" variant is assumed to be `true`, which is convient for splits that have variants of `true` and `false`. `ab` can be easily used in an if statement.
+The `test_track_visitor`'s `ab` method provides a convenient way to do two-way splits. The `true_variant` option is used to tell `ab` which variant is the "true" variant. If no `true_variant` option is provided, the "true" variant is assumed to be `true`, which is convenient for splits that have variants of `true` and `false`. `ab` can be easily used in an if statement.
 
 ```ruby
 # "button_color" split with "blue" and "red" variants


### PR DESCRIPTION
Update documentation of `TestTrackVisitor#ab` to more accurately reflect the `true_variant` option.

It seems like the documentation is referring to the `ab` method when it had an optional positional argument, but now it just has named options instead.