### PR TITLE
Add suggestion to run rake task for unknown splits

### DIFF
--- a/app/models/test_track/ab_configuration.rb
+++ b/app/models/test_track/ab_configuration.rb
@@ -9,10 +9,7 @@ class TestTrack::ABConfiguration
 
     @true_variant = true_variant.to_s if true_variant
 
-    if @split_registry && !split
-      raise ArgumentError, "unknown split: #{split_name}. " \
-        "#{'You may need to run rake test_track:schema:load' unless Rails.env.production?}"
-    end
+    raise ArgumentError, unknown_split_error_message if @split_registry && !split
   end
 
   def variants
@@ -35,6 +32,12 @@ class TestTrack::ABConfiguration
   end
 
   attr_reader :split_name, :split_registry
+
+  def unknown_split_error_message
+    error_message = "unknown split: #{split_name}."
+    error_message << " You may need to run rake test_track:schema:load" if Rails.env.development?
+    error_message
+  end
 
   def split
     split_registry && split_registry[split_name]

--- a/app/models/test_track/ab_configuration.rb
+++ b/app/models/test_track/ab_configuration.rb
@@ -9,7 +9,10 @@ class TestTrack::ABConfiguration
 
     @true_variant = true_variant.to_s if true_variant
 
-    raise ArgumentError, "unknown split: #{split_name}. You may need to run 'rake test_track:schema:load'" if @split_registry && !split
+    if @split_registry && !split
+      raise ArgumentError, "unknown split: #{split_name}. " \
+        "#{'You may need to run rake test_track:schema:load' unless Rails.env.production?}"
+    end
   end
 
   def variants

--- a/app/models/test_track/ab_configuration.rb
+++ b/app/models/test_track/ab_configuration.rb
@@ -9,7 +9,7 @@ class TestTrack::ABConfiguration
 
     @true_variant = true_variant.to_s if true_variant
 
-    raise ArgumentError, "unknown split: #{split_name}" if @split_registry && !split
+    raise ArgumentError, "unknown split: #{split_name}. You may need to run 'rake test_track:schema:load'" if @split_registry && !split
   end
 
   def variants

--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -9,7 +9,11 @@ class TestTrack::VaryDSL
     @context = require_option!(opts, :context)
     @split_registry = require_option!(opts, :split_registry, allow_nil: true)
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
-    raise ArgumentError, "unknown split: #{split_name}. You may need to run 'rake test_track:schema:load'" if @split_registry && !split
+
+    if @split_registry && !split
+      raise ArgumentError, "unknown split: #{split_name}. " \
+        "#{'You may need to run rake test_track:schema:load' unless Rails.env.production?}"
+    end
   end
 
   def when(*variants, &block)

--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -11,8 +11,8 @@ class TestTrack::VaryDSL
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 
     if @split_registry && !split
-      raise ArgumentError, "unknown split: #{split_name}. " \
-        "#{'You may need to run rake test_track:schema:load' unless Rails.env.production?}"
+      raise ArgumentError, "unknown split: #{split_name}." \
+        "#{' You may need to run rake test_track:schema:load.' if Rails.env.development?}"
     end
   end
 

--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -9,7 +9,7 @@ class TestTrack::VaryDSL
     @context = require_option!(opts, :context)
     @split_registry = require_option!(opts, :split_registry, allow_nil: true)
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
-    raise ArgumentError, "unknown split: #{split_name}" if @split_registry && !split
+    raise ArgumentError, "unknown split: #{split_name}. You may need to run 'rake test_track:schema:load'" if @split_registry && !split
   end
 
   def when(*variants, &block)

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TestTrack::ABConfiguration do
     it "raises a descriptive error when the split is not in the split_registry" do
       expect do
         described_class.new initialize_options.merge(split_name: :not_a_real_split)
-      end.to raise_error("unknown split: not_a_real_split")
+      end.to raise_error("unknown split: not_a_real_split. You may need to run 'rake test_track:schema:load'")
     end
   end
 

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -73,10 +73,21 @@ RSpec.describe TestTrack::ABConfiguration do
 
     context 'when in the development environment' do
       it 'gives a suggested fix' do
-        allow(Rails.env).to receive(:development?).and_return true
-        expect do
-          described_class.new initialize_options.merge(split_name: :not_a_real_split)
-        end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+        with_rails_env 'development' do
+          expect do
+            described_class.new initialize_options.merge(split_name: :not_a_real_split)
+          end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+        end
+      end
+    end
+
+    context 'when in production' do
+      it 'does not give a suggested fix' do
+        with_rails_env 'production' do
+          expect do
+            described_class.new initialize_options.merge(split_name: :not_a_real_split)
+          end.not_to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+        end
       end
     end
   end

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -68,7 +68,16 @@ RSpec.describe TestTrack::ABConfiguration do
     it "raises a descriptive error when the split is not in the split_registry" do
       expect do
         described_class.new initialize_options.merge(split_name: :not_a_real_split)
-      end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+      end.to raise_error("unknown split: not_a_real_split.")
+    end
+
+    context 'when in the development environment' do
+      it 'gives a suggested fix' do
+        allow(Rails.env).to receive(:development?).and_return true
+        expect do
+          described_class.new initialize_options.merge(split_name: :not_a_real_split)
+        end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+      end
     end
   end
 

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TestTrack::ABConfiguration do
     it "raises a descriptive error when the split is not in the split_registry" do
       expect do
         described_class.new initialize_options.merge(split_name: :not_a_real_split)
-      end.to raise_error("unknown split: not_a_real_split. You may need to run 'rake test_track:schema:load'")
+      end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
     end
   end
 

--- a/spec/models/test_track/vary_dsl_spec.rb
+++ b/spec/models/test_track/vary_dsl_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TestTrack::VaryDSL do
             split_registry: split_registry,
             context: "the_context"
           )
-        end.to raise_error("unknown split: not_a_real_split. You may need to run 'rake test_track:schema:load'")
+        end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
       end
     end
   end

--- a/spec/models/test_track/vary_dsl_spec.rb
+++ b/spec/models/test_track/vary_dsl_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe TestTrack::VaryDSL do
             split_registry: split_registry,
             context: "the_context"
           )
-        end.to raise_error("unknown split: not_a_real_split")
+        end.to raise_error("unknown split: not_a_real_split. You may need to run 'rake test_track:schema:load'")
       end
     end
   end

--- a/spec/models/test_track/vary_dsl_spec.rb
+++ b/spec/models/test_track/vary_dsl_spec.rb
@@ -70,7 +70,20 @@ RSpec.describe TestTrack::VaryDSL do
             split_registry: split_registry,
             context: "the_context"
           )
-        end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+        end.to raise_error("unknown split: not_a_real_split.")
+      end
+
+      context "when in the development environment" do
+        it "suggests a fix" do
+          allow(Rails.env).to receive(:development?).and_return true
+          expect do
+            described_class.new(
+              assignment: assignment,
+              split_registry: split_registry,
+              context: "the_context"
+            )
+          end.to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load.")
+        end
       end
     end
   end


### PR DESCRIPTION
A common fix for local test track schema getting out of sync is to run `rake test_track:schema:load`. This PR puts that suggestion in the error messages for unknown splits. 