### PR TITLE
TT connection errors and more

### DIFF
--- a/app/models/test_track/remote/split_registry.rb
+++ b/app/models/test_track/remote/split_registry.rb
@@ -30,7 +30,8 @@ class TestTrack::Remote::SplitRegistry
         instance.attributes
       end.freeze
     end
-  rescue *TestTrack::SERVER_ERRORS
+  rescue *TestTrack::SERVER_ERRORS => e
+    Rails.logger.error "TestTrack failed to load split registry. #{e}"
     nil # if we can't get a split registry
   end
 end

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -129,7 +129,7 @@ class TestTrack::Session
   end
 
   def sync_assignments?
-    !visitor.offline? && visitor.unsynced_assignments.present?
+    visitor.loaded? && visitor.unsynced_assignments.present?
   end
 
   def mixpanel_distinct_id

--- a/app/models/test_track/unsynced_assignments_notifier.rb
+++ b/app/models/test_track/unsynced_assignments_notifier.rb
@@ -17,7 +17,8 @@ class TestTrack::UnsyncedAssignmentsNotifier
       build_notify_assignment_job(assignment).tap do |job|
         begin
           job.perform
-        rescue *TestTrack::SERVER_ERRORS
+        rescue *TestTrack::SERVER_ERRORS => e
+          Rails.logger.error "TestTrack failed to notify unsynced assignments, retrying. #{e}"
           Delayed::Job.enqueue(build_notify_assignment_job(assignment))
         end
       end

--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -70,7 +70,9 @@ class TestTrack::Visitor
     begin
       identifier = TestTrack::Remote::Identifier.create!(identifier_opts)
       merge!(identifier.visitor)
-    rescue *TestTrack::SERVER_ERRORS
+    rescue *TestTrack::SERVER_ERRORS => e
+      Rails.logger.error "TestTrack failed to link identifier, retrying. #{e}"
+
       # If at first you don't succeed, async it - we may not display 100% consistent UX this time,
       # but subsequent requests will be better off
       TestTrack::Remote::Identifier.delay.create!(identifier_opts)
@@ -100,7 +102,8 @@ class TestTrack::Visitor
 
   def remote_visitor
     @remote_visitor ||= TestTrack::Remote::Visitor.find(id) unless tt_offline?
-  rescue *TestTrack::SERVER_ERRORS
+  rescue *TestTrack::SERVER_ERRORS => e
+    Rails.logger.error "TestTrack failed to load remote visitor. #{e}"
     @tt_offline = true
     nil
   end

--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -94,6 +94,10 @@ class TestTrack::Visitor
     @tt_offline
   end
 
+  def loaded?
+    !offline? && @remote_visitor.present?
+  end
+
   private
 
   def assignments

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -14,7 +14,7 @@ require 'request_store'
 module TestTrack
   module_function
 
-  SERVER_ERRORS = [Faraday::ConnectionError, Faraday::TimeoutError, Her::Errors::RemoteServerError].freeze
+  SERVER_ERRORS = [Faraday::ConnectionFailed, Faraday::TimeoutError, Her::Errors::RemoteServerError].freeze
 
   mattr_accessor :enabled_override
 

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -14,7 +14,7 @@ require 'request_store'
 module TestTrack
   module_function
 
-  SERVER_ERRORS = [Faraday::TimeoutError, Her::Errors::RemoteServerError].freeze
+  SERVER_ERRORS = [Faraday::ConnectionError, Faraday::TimeoutError, Her::Errors::RemoteServerError].freeze
 
   mattr_accessor :enabled_override
 

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -202,12 +202,19 @@ RSpec.describe TestTrack::Session do
     end
 
     context "assignments notifications with threading disabled" do
+      let(:registry) do
+        {
+          'bar' => { 'foo' => 0, 'baz' => 100 },
+          'switched_split' => { 'not_what_i_thought' => 100, 'originally_me' => 0 }
+        }
+      end
+
       before do
         allow(Thread).to receive(:new) do |&block|
           block.call
         end
 
-        allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return('bar' => { 'foo' => 0, 'baz' => 100 }, 'switched_split' => { 'not_what_i_thought' => 100, 'other' => 0 })
+        allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(registry)
       end
 
       context "new assignments" do
@@ -304,7 +311,7 @@ RSpec.describe TestTrack::Session do
 
           it "does not notify unsynced assignments" do
             subject.manage do
-              subject.visitor_dsl.ab('switched_split', true_variant: 'baz', context: :spec)
+              subject.visitor_dsl.ab('switched_split', true_variant: 'not_what_i_thought', context: :spec)
             end
 
             expect(TestTrack::UnsyncedAssignmentsNotifier).not_to have_received(:new)


### PR DESCRIPTION
/domain @jmileham @ceslami @rynonl @samandmoore 

There are a couple of things in here.

1. Added some logging so we have a better idea how often we're getting these timeouts, cuz right now we just swallow them all.
2. Add `Faraday::ConnectionError` to the list of ignored exceptions, since these started happening more frequently with the switch to MRI (maybe jruby doesn't honor these timeouts?)
3. Attempt to make session management a little more lazy, so we don't attempt to load the assignments if we don't need to.