### PR TITLE
Ability to sign_up new users from model mixin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gem 'rack', '~> 1.6' # Make sure travis can still run tests on older rubies
 
 gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+
+gem 'rake', '< 11.0' # http://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -46,6 +46,17 @@ module TestTrack::Identity
             end
           end
         end
+
+        define_method :test_track_sign_up! do
+          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
+          identifier_value = send(identifier_value_method)
+
+          if discriminator.participate_in_unauthenticated_session?
+            discriminator.controller.send(:test_track_session).sign_up! identifier_type, identifier_value
+          else
+            TestTrack::OfflineSession.create_visitor_for(identifier_type, identifier_value)
+          end
+        end
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -11,7 +11,7 @@ module TestTrack::Identity
         define_method :test_track_ab do |*args|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
 
-          if discriminator.participate_in_online_session?
+          if discriminator.authenticated_resource_matches_identity?
             discriminator.controller.send(:test_track_visitor).ab(*args)
           else
             identifier_value = send(identifier_value_method)
@@ -24,7 +24,7 @@ module TestTrack::Identity
         define_method :test_track_vary do |*args, &block|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
 
-          if discriminator.participate_in_online_session?
+          if discriminator.authenticated_resource_matches_identity?
             discriminator.controller.send(:test_track_visitor).vary(*args, &block)
           else
             identifier_value = send(identifier_value_method)
@@ -37,7 +37,7 @@ module TestTrack::Identity
         define_method :test_track_visitor_id do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
 
-          if discriminator.participate_in_online_session?
+          if discriminator.authenticated_resource_matches_identity?
             discriminator.controller.send(:test_track_visitor).id
           else
             identifier_value = send(identifier_value_method)

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -49,12 +49,23 @@ module TestTrack::Identity
 
         define_method :test_track_sign_up! do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          identifier_value = send(identifier_value_method)
 
-          if discriminator.participate_in_unauthenticated_session?
+          if discriminator.web_context?
+            identifier_value = send(identifier_value_method)
             discriminator.controller.send(:test_track_session).sign_up! identifier_type, identifier_value
           else
-            TestTrack::OfflineSession.create_visitor_for(identifier_type, identifier_value)
+            raise "test_track_sign_up! called outside of a web context"
+          end
+        end
+
+        define_method :test_track_log_in! do |opts = {}|
+          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
+
+          if discriminator.web_context?
+            identifier_value = send(identifier_value_method)
+            discriminator.controller.send(:test_track_session).log_in! identifier_type, identifier_value, opts
+          else
+            raise "test_track_log_in! called outside of a web context"
           end
         end
       end

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -2,7 +2,7 @@ module TestTrack::Identity
   extend ActiveSupport::Concern
 
   module ClassMethods
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
     def test_track_identifier(identifier_type, identifier_value_method)
       instance_methods = Module.new
       include instance_methods
@@ -70,6 +70,6 @@ module TestTrack::Identity
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
   end
 end

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -9,8 +9,8 @@ class TestTrack::IdentitySessionDiscriminator
     @controller ||= RequestStore[:test_track_controller]
   end
 
-  def participate_in_online_session?
-    authenticated_resource_matches_identity?
+  def authenticated_resource_matches_identity?
+    controller_has_authenticated_resource? && controller.send(authenticated_resource_method_name) == identity
   end
 
   def web_context?
@@ -18,10 +18,6 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   private
-
-  def authenticated_resource_matches_identity?
-    controller_has_authenticated_resource? && controller.send(authenticated_resource_method_name) == identity
-  end
 
   def controller_has_authenticated_resource?
     # pass true to `respond_to?` to include private methods

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -13,8 +13,8 @@ class TestTrack::IdentitySessionDiscriminator
     authenticated_resource_matches_identity?
   end
 
-  def participate_in_unauthenticated_session?
-    web_context? && !controller.respond_to?(authenticated_resource_method_name, true)
+  def web_context?
+    controller.present?
   end
 
   private
@@ -26,10 +26,6 @@ class TestTrack::IdentitySessionDiscriminator
   def controller_has_authenticated_resource?
     # pass true to `respond_to?` to include private methods
     web_context? && controller.respond_to?(authenticated_resource_method_name, true)
-  end
-
-  def web_context?
-    controller.present?
   end
 
   def authenticated_resource_method_name

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -13,6 +13,10 @@ class TestTrack::IdentitySessionDiscriminator
     authenticated_resource_matches_identity?
   end
 
+  def participate_in_unauthenticated_session?
+    web_context? && !controller.respond_to?(authenticated_resource_method_name, true)
+  end
+
   private
 
   def authenticated_resource_matches_identity?

--- a/app/models/test_track/offline_session.rb
+++ b/app/models/test_track/offline_session.rb
@@ -12,6 +12,10 @@ class TestTrack::OfflineSession
     end
   end
 
+  def self.create_visitor_for(identifier_type, identifier_value)
+    new(identifier_type, identifier_value).send :notify_unsynced_assignments!
+  end
+
   private
 
   attr_reader :identifier_type, :identifier_value
@@ -30,7 +34,7 @@ class TestTrack::OfflineSession
   def manage
     yield TestTrack::VisitorDSL.new(visitor)
   ensure
-    notify_unsynced_assignments! if unsynced_assignments?
+    notify_unsynced_assignments!
   end
 
   def unsynced_assignments?
@@ -41,6 +45,6 @@ class TestTrack::OfflineSession
     TestTrack::UnsyncedAssignmentsNotifier.new(
       visitor_id: visitor.id,
       assignments: visitor.unsynced_assignments
-    ).notify
+    ).notify if unsynced_assignments?
   end
 end

--- a/app/models/test_track/offline_session.rb
+++ b/app/models/test_track/offline_session.rb
@@ -12,10 +12,6 @@ class TestTrack::OfflineSession
     end
   end
 
-  def self.create_visitor_for(identifier_type, identifier_value)
-    new(identifier_type, identifier_value).send :notify_unsynced_assignments!
-  end
-
   private
 
   attr_reader :identifier_type, :identifier_value

--- a/spec/models/concerns/test_track/identity_spec.rb
+++ b/spec/models/concerns/test_track/identity_spec.rb
@@ -268,5 +268,33 @@ RSpec.describe TestTrack::Identity do
         end
       end
     end
+
+    context "#test_track_sign_up" do
+      context "in an offline session" do
+        it "signs up offline" do
+          allow(TestTrack::OfflineSession).to receive(:create_visitor_for)
+
+          subject.test_track_sign_up!
+
+          expect(TestTrack::OfflineSession).to have_received(:create_visitor_for).with("clown_id", 1234)
+        end
+      end
+
+      context "in a web context" do
+        let(:session) { TestTrack::Session.new(test_track_controller) }
+
+        it "signs up using the online session" do
+          allow(RequestStore).to receive(:exist?).and_return true
+          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
+          allow(session).to receive(:sign_up!)
+          allow(test_track_controller).to receive(:test_track_session).and_return(session)
+          
+          subject.test_track_sign_up!
+
+          expect(test_track_controller).to have_received(:test_track_session)
+          expect(session).to have_received(:sign_up!).with("clown_id", 1234)
+        end
+      end
+    end
   end
 end

--- a/spec/models/concerns/test_track/identity_spec.rb
+++ b/spec/models/concerns/test_track/identity_spec.rb
@@ -269,14 +269,10 @@ RSpec.describe TestTrack::Identity do
       end
     end
 
-    context "#test_track_sign_up" do
+    context "#test_track_sign_up!" do
       context "in an offline session" do
-        it "signs up offline" do
-          allow(TestTrack::OfflineSession).to receive(:create_visitor_for)
-
-          subject.test_track_sign_up!
-
-          expect(TestTrack::OfflineSession).to have_received(:create_visitor_for).with("clown_id", 1234)
+        it "raises" do
+          expect { subject.test_track_sign_up! }.to raise_error /called outside of a web context/
         end
       end
 
@@ -293,6 +289,30 @@ RSpec.describe TestTrack::Identity do
 
           expect(test_track_controller).to have_received(:test_track_session)
           expect(session).to have_received(:sign_up!).with("clown_id", 1234)
+        end
+      end
+    end
+
+    context "#test_track_log_in!" do
+      context "in an offline session" do
+        it "raises" do
+          expect { subject.test_track_log_in! }.to raise_error /called outside of a web context/
+        end
+      end
+
+      context "in a web context" do
+        let(:session) { TestTrack::Session.new(test_track_controller) }
+
+        it "signs up using the online session" do
+          allow(RequestStore).to receive(:exist?).and_return true
+          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
+          allow(session).to receive(:log_in!)
+          allow(test_track_controller).to receive(:test_track_session).and_return(session)
+          
+          subject.test_track_log_in!
+
+          expect(test_track_controller).to have_received(:test_track_session)
+          expect(session).to have_received(:log_in!).with("clown_id", 1234, {})
         end
       end
     end

--- a/spec/models/concerns/test_track/identity_spec.rb
+++ b/spec/models/concerns/test_track/identity_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe TestTrack::Identity do
           allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
           allow(session).to receive(:sign_up!)
           allow(test_track_controller).to receive(:test_track_session).and_return(session)
-          
+
           subject.test_track_sign_up!
 
           expect(test_track_controller).to have_received(:test_track_session)
@@ -308,7 +308,7 @@ RSpec.describe TestTrack::Identity do
           allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
           allow(session).to receive(:log_in!)
           allow(test_track_controller).to receive(:test_track_session).and_return(session)
-          
+
           subject.test_track_log_in!
 
           expect(test_track_controller).to have_received(:test_track_session)

--- a/spec/models/test_track/offline_session_spec.rb
+++ b/spec/models/test_track/offline_session_spec.rb
@@ -88,20 +88,4 @@ RSpec.describe TestTrack::OfflineSession do
       end
     end
   end
-
-  describe ".create_visitor_for" do
-    it "creates a visitor with the properties of the remote visitor" do
-      allow(TestTrack::Visitor).to receive(:new).and_call_original
-
-      described_class.create_visitor_for("clown_id", 1234)  
-
-      expect(TestTrack::Visitor).to have_received(:new) do |args|
-        expect(args[:id]).to eq("remote_visitor_id")
-        args[:assignments].first.tap do |assignment|
-          expect(assignment.split_name).to eq("foo")
-          expect(assignment.variant).to eq("bar")
-        end
-      end
-    end
-  end
 end

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "timecop"
   s.add_development_dependency "rubocop", ">= 0.36"
-  s.add_development_dependency "webmock", ">= 2.0.0"
+  s.add_development_dependency "webmock", "-> 2.1"
 
   s.required_ruby_version = '>= 1.9.3'
 end

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "timecop"
   s.add_development_dependency "rubocop", ">= 0.36"
-  s.add_development_dependency "webmock", "~> 2.1"
+  s.add_development_dependency "webmock", "~> 2.1.0"
 
   s.required_ruby_version = '>= 1.9.3'
 end

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "timecop"
   s.add_development_dependency "rubocop", ">= 0.36"
-  s.add_development_dependency "webmock", "-> 2.1"
+  s.add_development_dependency "webmock", "~> 2.1"
 
   s.required_ruby_version = '>= 1.9.3'
 end

--- a/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
+++ b/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "site_prism"
   s.add_dependency "rspec-rails"
   s.add_dependency "yarjuf"
-  s.add_dependency "webmock"
+  s.add_dependency "webmock", '~> 2.1' #avoid ruby 2.0 dependency
   s.add_dependency "rubocop", '< 0.42' #avoid ruby 2.0 dependency
   s.add_dependency "rspec-retry", "~> 0.4.5"
 end

--- a/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
+++ b/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "site_prism"
   s.add_dependency "rspec-rails"
   s.add_dependency "yarjuf"
-  s.add_dependency "webmock", '~> 2.1' #avoid ruby 2.0 dependency
+  s.add_dependency "webmock"
   s.add_dependency "rubocop", '< 0.42' #avoid ruby 2.0 dependency
   s.add_dependency "rspec-retry", "~> 0.4.5"
 end


### PR DESCRIPTION
/domain @jmileham @aburgel @samandmoore 

Currently the session discriminator works with either authenticated requests in a web context, or drops into an offline session that does not inspect the Test Track cookie at all. In practice, this is causing it to create a new visitor when we get a new signup and breaks the link between the new signup and the visitor he/she was prior to finishing the signup flow.

For brand new users, we want to `sign_up` to the Test Track server with their newly created application identifier and their existing visitor id that they've used up until this point. 

This PR adds a 3rd method that TestTrack::Identity injects into models it is included in called `test_track_sign_up`. It is meant to be called once per user signup and associates the local service's identifier(e.g. UserId) with the existing visitor id.  If an offline context is still inferred, we have no choice but to create a new visitor.