### PR TITLE
appease rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,9 @@ Style/ClassAndModuleChildren:
 Style/AlignParameters:
   Enabled: false
 
+Style/IndentArray:
+  EnforcedStyle: consistent
+
 Style/ClosingParenthesisIndentation:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,6 +84,9 @@ Style/AlignParameters:
 Style/IndentArray:
   EnforcedStyle: consistent
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/ClosingParenthesisIndentation:
   Enabled: false
 

--- a/spec/models/test_track/fake/split_registry_spec.rb
+++ b/spec/models/test_track/fake/split_registry_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
       it 'returns an array of splits' do
         expect(subject.splits).to eq [
           TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 50, 'true' => 50),
-          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 34, 'white' => 33, 'red' => 33)]
+          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 34, 'white' => 33, 'red' => 33)
+        ]
       end
     end
   end

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -47,12 +47,10 @@ RSpec.describe TestTrack::Visitor do
 
   describe "#unsynced_assignments" do
     it "returns the passed in unsynced assignments" do
-      visitor = TestTrack::Visitor.new(assignments:
-        [
-          instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: true),
-          instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
-        ]
-      )
+      visitor = TestTrack::Visitor.new(assignments: [
+        instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: true),
+        instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
+      ])
 
       expect(visitor.unsynced_assignments.count).to eq 1
       expect(visitor.unsynced_assignments.first.split_name).to eq "foo"
@@ -80,12 +78,10 @@ RSpec.describe TestTrack::Visitor do
 
   describe "#assignment_registry" do
     it "return a hash generated from the passed in assignments" do
-      visitor = TestTrack::Visitor.new(assignments:
-        [
-          instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: false),
-          instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
-        ]
-      )
+      visitor = TestTrack::Visitor.new(assignments: [
+        instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: false),
+        instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
+      ])
 
       expect(visitor.assignment_registry["foo"].variant).to eq("baz")
       expect(visitor.assignment_registry["bar"].variant).to eq("buz")


### PR DESCRIPTION
/domain @samandmoore @jmileham 

The default array indentation is pretty funky with the new rubocop version, so flipped it to be something closer to what we use elsewhere.

http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IndentArray