### PR TITLE
Raise on misconfiguration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - 'build/**/*'
   DisplayStyleGuide: true
   DisplayCopNames: true
+
 Rails:
   Enabled: true
 
@@ -55,6 +56,9 @@ Lint/AmbiguousRegexpLiteral:
 Style/Documentation:
   Enabled: false
 
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Style/StringLiterals:
   Enabled: false
 
@@ -81,6 +85,12 @@ Style/ClassAndModuleChildren:
 Style/AlignParameters:
   Enabled: false
 
+Style/IndentArray:
+  EnforcedStyle: consistent
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/ClosingParenthesisIndentation:
   Enabled: false
 
@@ -100,4 +110,7 @@ Rails/FindEach:
   Enabled: false
 
 Style/GuardClause:
+  Enabled: false
+
+Performance/RedundantMatch:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ gem 'rack', '~> 1.6' # Make sure travis can still run tests on older rubies
 gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
 
-gem 'nokogiri', '~> 1.6.8'
-gem 'webmock', '~> 2.2.0'
+gem 'nokogiri', '< 1.7.0'
+gem 'webmock', '< 2.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rubocop', '< 0.38', require: false
+gem 'rubocop', '< 0.42', require: false
 gem 'simplecov', require: false
 gem 'shoulda-matchers', '~> 2.8', require: false
 gem 'jbuilder', '~> 2.0'
@@ -17,3 +17,4 @@ gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
 
 gem 'nokogiri', '~> 1.6.8'
+gem 'webmock', '~> 2.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gem 'rack', '~> 1.6' # Make sure travis can still run tests on older rubies
 
 gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
+
+gem 'nokogiri', '~> 1.6.8'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TestTrack Rails Client
 
-[![Build Status](https://travis-ci.org/Betterment/test_track_rails_client.svg?branch=master)](https://travis-ci.com/Betterment/test_track_rails_client)
+[![Build Status](https://travis-ci.org/Betterment/test_track_rails_client.svg?branch=master)](https://travis-ci.org/Betterment/test_track_rails_client)
 
 This is the Rails client library for the [TestTrack](https://github.com/Betterment/test_track) system.
 

--- a/app/models/test_track/misconfiguration_notifier.rb
+++ b/app/models/test_track/misconfiguration_notifier.rb
@@ -1,5 +1,7 @@
 class TestTrack::MisconfigurationNotifier
   def notify(msg)
+    raise msg if Rails.env.development? || Rails.env.test?
+
     Rails.logger.error(msg)
 
     if Airbrake.respond_to?(:notify_or_ignore)

--- a/app/models/test_track/misconfiguration_notifier.rb
+++ b/app/models/test_track/misconfiguration_notifier.rb
@@ -3,9 +3,9 @@ class TestTrack::MisconfigurationNotifier
     Rails.logger.error(msg)
 
     if Airbrake.respond_to?(:notify_or_ignore)
-      Airbrake.notify_or_ignore(msg)
+      Airbrake.notify_or_ignore(StandardError.new, error_message: msg)
     else
-      Airbrake.notify(msg)
+      Airbrake.notify(StandardError.new, error_message: msg)
     end
   end
 end

--- a/spec/models/test_track/fake/split_registry_spec.rb
+++ b/spec/models/test_track/fake/split_registry_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
       it 'returns an array of splits' do
         expect(subject.splits).to eq [
           TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 50, 'true' => 50),
-          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 34, 'white' => 33, 'red' => 33)]
+          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 34, 'white' => 33, 'red' => 33)
+        ]
       end
     end
   end

--- a/spec/models/test_track/misconfiguration_notifier_spec.rb
+++ b/spec/models/test_track/misconfiguration_notifier_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
 
       it "calls Airbrake.notify_or_ignore" do
         subject.notify("something is misconfigured")
-        expect(Airbrake).to have_received(:notify_or_ignore).with("something is misconfigured").exactly(:once)
+        expect(Airbrake).to have_received(:notify_or_ignore).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
       end
 
       it "does not call Airbrake.notify" do
@@ -36,7 +36,7 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
 
       it "calls Airbrake.notify" do
         subject.notify("something is misconfigured")
-        expect(Airbrake).to have_received(:notify).with("something is misconfigured").exactly(:once)
+        expect(Airbrake).to have_received(:notify).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
       end
     end
   end

--- a/spec/models/test_track/misconfiguration_notifier_spec.rb
+++ b/spec/models/test_track/misconfiguration_notifier_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
 
         it "calls Airbrake.notify_or_ignore" do
           subject.notify("something is misconfigured")
-          expect(Airbrake).to have_received(:notify_or_ignore).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+          expect(Airbrake).to have_received(:notify_or_ignore)
+            .with(kind_of(StandardError), error_message: "something is misconfigured")
+            .exactly(:once)
         end
 
         it "does not call Airbrake.notify" do
@@ -67,7 +69,9 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
 
         it "calls Airbrake.notify" do
           subject.notify("something is misconfigured")
-          expect(Airbrake).to have_received(:notify).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+          expect(Airbrake).to have_received(:notify)
+            .with(kind_of(StandardError), error_message: "something is misconfigured")
+            .exactly(:once)
         end
       end
     end

--- a/spec/models/test_track/misconfiguration_notifier_spec.rb
+++ b/spec/models/test_track/misconfiguration_notifier_spec.rb
@@ -4,39 +4,71 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
   subject { TestTrack::MisconfigurationNotifier.new }
 
   describe "#notify" do
-    before do
-      allow(Rails.logger).to receive(:error).and_call_original
+    context "in development environment" do
+      around do |example|
+        with_rails_env "development" do
+          example.run
+        end
+      end
+
+      it "raises" do
+        expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
+      end
     end
 
-    it "does a rails error log" do
-      subject.notify("something is misconfigured")
-      expect(Rails.logger).to have_received(:error).with("something is misconfigured")
+    context "in test environment" do
+      around do |example|
+        with_rails_env "test" do
+          example.run
+        end
+      end
+
+      it "raises" do
+        expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
+      end
     end
 
-    context "given an Airbrake that responds to .notify_or_ignore and .notify" do
+    context "in production environment" do
       before do
-        stub_const("Airbrake", double("Airbrake", notify: nil, notify_or_ignore: nil))
+        allow(Rails.logger).to receive(:error).and_call_original
       end
 
-      it "calls Airbrake.notify_or_ignore" do
+      around do |example|
+        with_rails_env "production" do
+          example.run
+        end
+      end
+
+      it "does a rails error log" do
         subject.notify("something is misconfigured")
-        expect(Airbrake).to have_received(:notify_or_ignore).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+        expect(Rails.logger).to have_received(:error).with("something is misconfigured")
       end
 
-      it "does not call Airbrake.notify" do
-        subject.notify("something is misconfigured")
-        expect(Airbrake).not_to have_received(:notify)
-      end
-    end
+      context "given an Airbrake that responds to .notify_or_ignore and .notify" do
+        before do
+          stub_const("Airbrake", double("Airbrake", notify: nil, notify_or_ignore: nil))
+        end
 
-    context "given an Airbrake that only responds to .notify" do
-      before do
-        stub_const("Airbrake", double("Airbrake", notify: nil))
+        it "calls Airbrake.notify_or_ignore" do
+          subject.notify("something is misconfigured")
+          expect(Airbrake).to have_received(:notify_or_ignore).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+        end
+
+        it "does not call Airbrake.notify" do
+          subject.notify("something is misconfigured")
+          expect(Airbrake).not_to have_received(:notify)
+        end
       end
 
-      it "calls Airbrake.notify" do
-        subject.notify("something is misconfigured")
-        expect(Airbrake).to have_received(:notify).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+      context "given an Airbrake that only responds to .notify" do
+        before do
+          stub_const("Airbrake", double("Airbrake", notify: nil))
+        end
+
+        it "calls Airbrake.notify" do
+          subject.notify("something is misconfigured")
+          expect(Airbrake).to have_received(:notify).with(kind_of(StandardError), error_message: "something is misconfigured").exactly(:once)
+        end
       end
     end
   end

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -47,12 +47,10 @@ RSpec.describe TestTrack::Visitor do
 
   describe "#unsynced_assignments" do
     it "returns the passed in unsynced assignments" do
-      visitor = TestTrack::Visitor.new(assignments:
-        [
-          instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: true),
-          instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
-        ]
-      )
+      visitor = TestTrack::Visitor.new(assignments: [
+        instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: true),
+        instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
+      ])
 
       expect(visitor.unsynced_assignments.count).to eq 1
       expect(visitor.unsynced_assignments.first.split_name).to eq "foo"
@@ -80,12 +78,10 @@ RSpec.describe TestTrack::Visitor do
 
   describe "#assignment_registry" do
     it "return a hash generated from the passed in assignments" do
-      visitor = TestTrack::Visitor.new(assignments:
-        [
-          instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: false),
-          instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
-        ]
-      )
+      visitor = TestTrack::Visitor.new(assignments: [
+        instance_double(TestTrack::Assignment, split_name: 'foo', variant: 'baz', unsynced?: false),
+        instance_double(TestTrack::Assignment, split_name: 'bar', variant: 'buz', unsynced?: false)
+      ])
 
       expect(visitor.assignment_registry["foo"].variant).to eq("baz")
       expect(visitor.assignment_registry["bar"].variant).to eq("buz")

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -275,8 +275,14 @@ RSpec.describe TestTrack::Visitor do
         expect(new_visitor.ab("blue_button", context: :spec)).to eq false
       end
 
-      it "returns false when split variants are not true and false" do
-        expect(new_visitor.ab("time", context: :spec)).to eq false
+      it "returns false in production when split variants are not true and false" do
+        with_rails_env "production" do
+          expect(new_visitor.ab("time", context: :spec)).to eq false
+        end
+      end
+
+      it "raises in test environment when split variants are not true and false" do
+        expect { new_visitor.ab("time", context: :spec) }.to raise_exception "vary for \"time\" configures unknown variant \"true\""
       end
     end
   end


### PR DESCRIPTION
/domain @jmileham @rynonl @samandmoore 

This does two things.

1) Fixes how we send events to Airbrake, it [expects an exception and an optional message](http://www.rubydoc.info/github/thoughtbot/airbrake/Airbrake.notify), not just a message. 

2) In development and test environments, raise when a `.vary` or `.ab` call is misconfigured.