### PR TITLE
Revert raise on misconfig

### DIFF
--- a/app/models/test_track/misconfiguration_notifier.rb
+++ b/app/models/test_track/misconfiguration_notifier.rb
@@ -1,6 +1,6 @@
 class TestTrack::MisconfigurationNotifier
   def notify(msg)
-    raise msg if Rails.env.development? || Rails.env.test?
+    raise msg if Rails.env.development?
 
     Rails.logger.error(msg)
 

--- a/spec/assignment_helper_spec.rb
+++ b/spec/assignment_helper_spec.rb
@@ -23,5 +23,21 @@ RSpec.describe TestTrackRailsClient::AssignmentHelper do
         expect { stub_test_track_assignments(foo: :bar) }.to raise_error(/Cannot stub test track assignments/)
       end
     end
+
+    it 'works correctly with a vary call' do
+      stub_test_track_assignments(foo: :bar)
+
+      visitor = TestTrack::Visitor.new
+      expect do
+        visitor.vary(:foo, context: :spec) do |v|
+          v.when :bar do
+            # noop
+          end
+          v.default :baz do
+            raise "this branch shouldn't be executed"
+          end
+        end
+      end.not_to raise_error
+    end
   end
 end

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe TestTrack::ABConfiguration do
         with_rails_env 'production' do
           expect do
             described_class.new initialize_options.merge(split_name: :not_a_real_split)
-          end.not_to raise_error("unknown split: not_a_real_split. You may need to run rake test_track:schema:load")
+          end.to raise_error("unknown split: not_a_real_split.")
         end
       end
     end

--- a/spec/models/test_track/misconfiguration_notifier_spec.rb
+++ b/spec/models/test_track/misconfiguration_notifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
     context "in development environment" do
       it "raises" do
         with_rails_env "development" do
-          expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
+          expect { subject.notify("something is misconfigured") }.to raise_error 'something is misconfigured'
         end
       end
     end
@@ -15,7 +15,7 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
     context "in test environment" do
       it "does not raise" do
         with_rails_env "test" do
-          expect { subject.notify("something is misconfigured") }.not_to raise_exception
+          expect { subject.notify("something is misconfigured") }.not_to raise_error
         end
       end
     end

--- a/spec/models/test_track/misconfiguration_notifier_spec.rb
+++ b/spec/models/test_track/misconfiguration_notifier_spec.rb
@@ -5,26 +5,18 @@ RSpec.describe TestTrack::MisconfigurationNotifier do
 
   describe "#notify" do
     context "in development environment" do
-      around do |example|
-        with_rails_env "development" do
-          example.run
-        end
-      end
-
       it "raises" do
-        expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
+        with_rails_env "development" do
+          expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
+        end
       end
     end
 
     context "in test environment" do
-      around do |example|
+      it "does not raise" do
         with_rails_env "test" do
-          example.run
+          expect { subject.notify("something is misconfigured") }.not_to raise_exception
         end
-      end
-
-      it "raises" do
-        expect { subject.notify("something is misconfigured") }.to raise_exception 'something is misconfigured'
       end
     end
 

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -277,8 +277,10 @@ RSpec.describe TestTrack::Visitor do
         end
       end
 
-      it "raises in test environment when split variants are not true and false" do
-        expect { new_visitor.ab("time", context: :spec) }.to raise_exception "vary for \"time\" configures unknown variant \"true\""
+      it "raises in development environment when split variants are not true and false" do
+        with_rails_env "development" do
+          expect { new_visitor.ab("time", context: :spec) }.to raise_exception "vary for \"time\" configures unknown variant \"true\""
+        end
       end
     end
   end

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe TestTrack::Visitor do
 
       it "raises in development environment when split variants are not true and false" do
         with_rails_env "development" do
-          expect { new_visitor.ab("time", context: :spec) }.to raise_exception "vary for \"time\" configures unknown variant \"true\""
+          expect { new_visitor.ab("time", context: :spec) }.to raise_error "vary for \"time\" configures unknown variant \"true\""
         end
       end
     end


### PR DESCRIPTION
/domain @jmileham @samandmoore @rynonl 

I'm reverting this because it didn't work with stubbed splits. When stubbing, we only register a single variant, so a vary call that refers to any other variant will get flagged as a misconfiguration.

There's no good way to know the actual variants of a split unless you load the `test_track_schema.yml` file, but that might not always be available in a test environment.