### PR TITLE
Use the requesting thread’s RequestStore when syncing assignments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: ruby
+
 rvm:
 - 1.9.3
 - jruby-19mode
 - 2.0.0
+
+before_install:
+- gem update --system
+- gem install bundler
+
 before_script:
 - RAILS_ENV=test bundle exec rake db:setup

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby '>= 1.9.3'
 
 gemspec
 

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -174,12 +174,12 @@ class TestTrack::Session
     ENV['TEST_TRACK_FULLY_QUALIFIED_COOKIE_DOMAIN_ENABLED'] == '1'
   end
 
-  def new_thread_with_request_store(&block)
+  def new_thread_with_request_store
     Thread.new(RequestStore.store) do |original_store|
       begin
         RequestStore.begin!
         RequestStore.store.merge!(original_store)
-        block.call
+        yield
       ensure
         RequestStore.end!
         RequestStore.clear!

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -210,8 +210,8 @@ RSpec.describe TestTrack::Session do
       end
 
       before do
-        allow(Thread).to receive(:new) do |&block|
-          block.call
+        allow(Thread).to receive(:new) do |*args, &block|
+          block.call(*args)
         end
 
         allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(registry)

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -363,6 +363,25 @@ RSpec.describe TestTrack::Session do
 
       expect(unsynced_assignments_notifier).to have_received(:notify)
     end
+
+    let(:notifier) { instance_double(TestTrack::UnsyncedAssignmentsNotifier) }
+
+    it "passes along RequestStore contents to the background thread" do
+      RequestStore[:stashed_object] = 'stashed object'
+      found_object = nil
+
+      allow(TestTrack::UnsyncedAssignmentsNotifier).to receive(:new).and_return(notifier)
+      allow(notifier).to receive(:notify) do
+        found_object = RequestStore[:stashed_object]
+      end
+
+      notifier_thread = subject.send(:notify_unsynced_assignments!)
+
+      # block until thread completes
+      notifier_thread.join
+
+      expect(found_object).to eq 'stashed object'
+    end
   end
 
   describe "#visitor_dsl" do


### PR DESCRIPTION
/domain @rynonl @jmileham 

The notifier jobs call out to application code via the analytics plugin, but since we also fork a new thread when notifying unsynced assignments, we lose any per-request context in RequestStore.

This copies the calling thread's RequestStore into the notifying thread, so analytics plugins can still access that data.