### PR TITLE
Stub split registry with default variants during testing

### DIFF
--- a/app/models/test_track/fake/split_registry.rb
+++ b/app/models/test_track/fake/split_registry.rb
@@ -6,11 +6,7 @@ class TestTrack::Fake::SplitRegistry
   end
 
   def to_h
-    if test_track_schema_yml.present?
-      test_track_schema_yml[:splits]
-    else
-      {}
-    end
+    @to_h ||= splits_with_deterministic_weights
   end
 
   def splits
@@ -21,6 +17,14 @@ class TestTrack::Fake::SplitRegistry
 
   private
 
+  def split_hash
+    if test_track_schema_yml.present?
+      test_track_schema_yml[:splits]
+    else
+      {}
+    end
+  end
+
   def test_track_schema_yml
     unless instance_variable_defined?(:@test_track_schema_yml)
       @test_track_schema_yml = _test_track_schema_yml
@@ -29,8 +33,25 @@ class TestTrack::Fake::SplitRegistry
   end
 
   def _test_track_schema_yml
-    YAML.load_file("#{Rails.root}/db/test_track_schema.yml").with_indifferent_access
+    YAML.load_file(test_track_schema_yml_path).with_indifferent_access
   rescue
     nil
+  end
+
+  def test_track_schema_yml_path
+    ENV["TEST_TRACK_SCHEMA_FILE_PATH"] || "#{Rails.root}/db/test_track_schema.yml"
+  end
+
+  def splits_with_deterministic_weights
+    split_hash.each_with_object({}) do |(split_name, weighting_registry), split_registry|
+      default_variant = weighting_registry.keys.sort.first
+
+      adjusted_weights = { default_variant => 100 }
+      weighting_registry.except(default_variant).keys.each do |variant|
+        adjusted_weights[variant] = 0
+      end
+
+      split_registry[split_name] = adjusted_weights
+    end
   end
 end

--- a/app/models/test_track/fake/visitor.rb
+++ b/app/models/test_track/fake/visitor.rb
@@ -1,5 +1,3 @@
-require 'digest'
-
 class TestTrack::Fake::Visitor
   attr_reader :id
 
@@ -21,21 +19,16 @@ class TestTrack::Fake::Visitor
     @assignments ||= _assignments
   end
 
+  def split_registry
+    TestTrack::Fake::SplitRegistry.instance.to_h
+  end
+
   private
 
   def _assignments
-    TestTrack::Fake::SplitRegistry.instance.splits.map do |split|
-      index = hash_fixnum(split.name) % split.registry.keys.size
-      variant = split.registry.keys[index]
-      Assignment.new(split.name, variant, false, "the_context")
+    split_registry.keys.map do |split_name|
+      variant = TestTrack::VariantCalculator.new(visitor: self, split_name: split_name).variant
+      Assignment.new(split_name, variant, false, "the_context")
     end
-  end
-
-  def hash_fixnum(split_name)
-    split_visitor_hash(split_name).slice(0, 8).to_i(16)
-  end
-
-  def split_visitor_hash(split_name)
-    Digest::MD5.new.update(split_name.to_s + id.to_s).hexdigest
   end
 end

--- a/lib/test_track_rails_client/assignment_helper.rb
+++ b/lib/test_track_rails_client/assignment_helper.rb
@@ -1,13 +1,12 @@
 module TestTrackRailsClient::AssignmentHelper
-  def stub_test_track_assignments(assignment_registry) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def stub_test_track_assignments(assignment_registry) # rubocop:disable Metrics/AbcSize
     raise "Cannot stub test track assignments when TestTrack is enabled" if TestTrack.enabled?
 
-    split_registry = {}
+    split_registry = TestTrack::Fake::SplitRegistry.instance.to_h.dup
     assignments = []
 
     assignment_registry.each do |split_name, variant|
-      assignment_registry[split_name] = variant.to_s
-      split_registry[split_name] = { variant => 100 }
+      split_registry[split_name] = { variant => 100 } unless split_registry[split_name]
       assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
     end
 

--- a/spec/assignment_helper_spec.rb
+++ b/spec/assignment_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TestTrackRailsClient::AssignmentHelper do
     it "overrides split registry with a trivial split set" do
       stub_test_track_assignments(foo: :bar)
 
-      expect(TestTrack::Remote::SplitRegistry.to_hash).to eq('foo' => { 'bar' => 100 })
+      expect(TestTrack::Remote::SplitRegistry.to_hash).to include('foo' => { 'bar' => 100 })
     end
 
     it 'raises if test track is enabled' do

--- a/spec/models/test_track/fake/split_registry_spec.rb
+++ b/spec/models/test_track/fake/split_registry_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
 
   context 'when test_track_schema.yml exists' do
     describe '#to_h' do
-      it 'returns a hash containing all splits' do
+      it 'returns a hash containing all splits with deterministic weights' do
         expect(subject.to_h).to eq(
           {
             buy_one_get_one_promotion_enabled: {
-              false: 50,
-              true: 50
+              false: 100,
+              true: 0
             },
             banner_color: {
-              blue: 34,
-              white: 33,
-              red: 33
+              blue: 100,
+              white: 0,
+              red: 0
             }
           }.with_indifferent_access
         )
@@ -23,10 +23,10 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
     end
 
     describe '#splits' do
-      it 'returns an array of splits' do
+      it 'returns an array of splits with deterministic weights' do
         expect(subject.splits).to eq [
-          TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 50, 'true' => 50),
-          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 34, 'white' => 33, 'red' => 33)
+          TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 100, 'true' => 0),
+          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 100, 'white' => 0, 'red' => 0)
         ]
       end
     end

--- a/spec/models/test_track/fake/visitor_spec.rb
+++ b/spec/models/test_track/fake/visitor_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TestTrack::Fake::Visitor do
       it 'returns an array of assignments' do
         expect(subject.assignments).to match_array [
           TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context"),
-          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'white', false, "the_context")
+          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context")
         ]
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe TestTrack::Fake::Visitor do
 
   context 'when splits do not exist' do
     before do
-      allow(TestTrack::Fake::SplitRegistry.instance).to receive(:splits).and_return([])
+      allow(TestTrack::Fake::SplitRegistry.instance).to receive(:to_h).and_return({})
     end
 
     describe '#assignments' do


### PR DESCRIPTION
/domain @samandmoore @jmileham @rynonl 

This stubs the split registry before each test, setting one variant as the default so tests are deterministic. You'll no longer need to stub assignments before each spec, unless you have a particular need to.

I'm using the `test_track_schema.yml` file to generate the splits to stub. There are two issues with this.

1. The file will get loaded before each spec, which may slow things down a bit. We can do some caching, but I'm not sure where the best place to do this is.

2. The location of the file is fixed, which may not work in some apps. How should we make this configurable?

LMK if this approach seems sound and then I'll update the specs.