### PR TITLE
[Feedback] Provide an opt out from using the web session

### DIFF
--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -5,6 +5,18 @@ module TestTrack::Controller
     helper_method :test_track_session, :test_track_visitor
     helper TestTrack::ApplicationHelper
     around_action :manage_test_track_session
+
+    class_attribute :test_track_web_context_disabled
+  end
+
+  module ClassMethods
+    def disable_test_track_web_context
+      self.test_track_web_context_disabled = true
+    end
+  end
+
+  def test_track_web_context_disabled?
+    self.class.test_track_web_context_disabled
   end
 
   private

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -14,7 +14,7 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   def web_context?
-    controller.present?
+    controller.present? && !controller.test_track_web_context_disabled?
   end
 
   private


### PR DESCRIPTION
/domain @abeniwal @jmileham @samandmoore 

We've seen some strange behavior when using TestTrack on authenticated native mobile endpoints. Because the endpoint is authenticated, the controller has an authenticated resource method (i.e. `current_user`), but it's being accessed by native mobile clients, so there aren't any cookies being passed.

This will cause the TestTrack rails client to generate a new visitor, even though the user may already be associated with one because it's never using an offline session. 

This PR provides way for controllers to opt out of using the web session if they will never have a TestTrack cookie.

This is likely a short term fix since at some point we'll need a way for mobile clients to pass along their TT visitor ID.

TODO
- [ ] Write specs