### PR TITLE
Allow test_track_visitor_id to be passed via headers

### DIFF
--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -98,6 +98,10 @@ class TestTrack::Visitor
     !offline? && @remote_visitor.present?
   end
 
+  def id_overridden_by_existing_visitor?
+    @id_overridden_by_existing_visitor || false
+  end
+
   private
 
   def assignments
@@ -113,6 +117,7 @@ class TestTrack::Visitor
   end
 
   def merge!(other)
+    @id_overridden_by_existing_visitor = id != other.id
     @id = other.id
     @assignment_registry = assignment_registry.merge(other.assignment_registry)
     @unsynced_assignments = nil


### PR DESCRIPTION
/domain @jmileham @samandmoore @aburgel

From our conversation in the test_track channel, allowing the session to be read from the request header.

Still need to write back the test track visitor id in the response header. Should this only be passed back when the request has the TT visitor id in the header, or should it always be passed back?

Still need to do a proper integration test.