### PR TITLE
Use main session after signup/login

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ def alias(visitor_id, existing_id)
 
 ## Upgrading
 
-### From 1.x to 1.4
+### From 1.x to 1.3
 
 `TestTrack::Session#log_in!` and `TestTrack:Session#sign_up!` now take a `TestTrack::Identity` instance argument instead of an identity type and identity value.
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ def alias(visitor_id, existing_id)
 
 ## Upgrading
 
-### From 1.x to 2.0
+### From 1.x to 1.4
 
 `TestTrack::Session#log_in!` and `TestTrack:Session#sign_up!` now take a `TestTrack::Identity` instance argument instead of an identity type and identity value.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ It provides server-side split-testing and feature-toggling through a simple API.
 
 If you're looking to do client-side assignment, then check out our [JS client](https://github.com/Betterment/test_track_js_client).
 
+* [Installation](#installation)
+* [Concepts](#concepts)
+* [Configuring the TestTrack server from your app](#configuring-the-testtrack-server-from-your-app)
+* [Varying app behavior based on assigned variant](#varying-app-behavior-based-on-assigned-variant)
+* [Tracking visitor logins](#tracking-visitor-logins)
+* [Tracking signups](#tracking-signups)
+* [Testing splits](#testing-splits)
+* [Custom Analytics](#custom-analytics)
+* [Upgrading](#upgrading)
+* [How to Contribute](#how-to-contribute)
+
 ## Installation
 
 Install the gem:
@@ -351,7 +362,7 @@ def alias(visitor_id, existing_id)
 
 ## Upgrading
 
-### to 2.0
+### From 1.x to 2.0
 
 `TestTrack::Session#log_in!` and `TestTrack:Session#sign_up!` now take a `TestTrack::Identity` instance argument instead of an identity type and identity value.
 

--- a/README.md
+++ b/README.md
@@ -349,6 +349,12 @@ def track_assignment(visitor_id, assignment, properties)
 def alias(visitor_id, existing_id)
 ```
 
+## Upgrading
+
+### to 2.0
+
+`TestTrack::Session#log_in!` and `TestTrack:Session#sign_up!` now take a `TestTrack::Identity` instance argument instead of an identity type and identity value.
+
 ## How to Contribute
 
 We would love for you to contribute! Anything that benefits the majority of `test_track` users—from a documentation fix to an entirely new feature—is encouraged.

--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -18,7 +18,7 @@ module TestTrack::Controller
   end
 
   def manage_test_track_session
-    RequestStore[:test_track_controller] = self
+    RequestStore[:test_track_session] = test_track_session
     test_track_session.manage do
       yield
     end

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -17,37 +17,39 @@ module TestTrack::Identity
 
         define_method :test_track_ab do |*args|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.test_track_visitor do |v|
+          discriminator.with_visitor do |v|
             v.ab(*args)
           end
         end
 
         define_method :test_track_vary do |*args, &block|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.test_track_visitor do |v|
+          discriminator.with_visitor do |v|
             v.vary(*args, &block)
           end
         end
 
         define_method :test_track_visitor_id do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.test_track_visitor do |v|
+          discriminator.with_visitor do |v|
             v.id
           end
         end
 
         define_method :test_track_sign_up! do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-
-          identifier_value = send(identifier_value_method)
-          discriminator.test_track_session.sign_up! identifier_type, identifier_value
+          discriminator.with_session do |session|
+            identifier_value = send(identifier_value_method)
+            session.sign_up! identifier_type, identifier_value
+          end
         end
 
         define_method :test_track_log_in! do |opts = {}|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-
-          identifier_value = send(identifier_value_method)
-          discriminator.test_track_session.log_in! identifier_type, identifier_value, opts
+          discriminator.with_session do |session|
+            identifier_value = send(identifier_value_method)
+            session.log_in! identifier_type, identifier_value
+          end
         end
       end
     end

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -2,7 +2,7 @@ module TestTrack::Identity
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def test_track_identifier(identifier_type, identifier_value_method) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
+    def test_track_identifier(identifier_type, identifier_value_method) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
       instance_methods = Module.new
       include instance_methods
 

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -2,74 +2,54 @@ module TestTrack::Identity
   extend ActiveSupport::Concern
 
   module ClassMethods
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
-    def test_track_identifier(identifier_type, identifier_value_method)
+    def test_track_identifier(identifier_type, identifier_value_method) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
       instance_methods = Module.new
       include instance_methods
 
       instance_methods.module_eval do
+        define_method :test_track_identifier_type do
+          identifier_type
+        end
+
+        define_method :test_track_identifier_value do
+          send(identifier_value_method)
+        end
+
         define_method :test_track_ab do |*args|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-
-          if discriminator.authenticated_resource_matches_identity?
-            discriminator.controller.send(:test_track_visitor).ab(*args)
-          else
-            identifier_value = send(identifier_value_method)
-            TestTrack::OfflineSession.with_visitor_for(identifier_type, identifier_value) do |v|
-              v.ab(*args)
-            end
+          discriminator.test_track_visitor do |v|
+            v.ab(*args)
           end
         end
 
         define_method :test_track_vary do |*args, &block|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-
-          if discriminator.authenticated_resource_matches_identity?
-            discriminator.controller.send(:test_track_visitor).vary(*args, &block)
-          else
-            identifier_value = send(identifier_value_method)
-            TestTrack::OfflineSession.with_visitor_for(identifier_type, identifier_value) do |v|
-              v.vary(*args, &block)
-            end
+          discriminator.test_track_visitor do |v|
+            v.vary(*args, &block)
           end
         end
 
         define_method :test_track_visitor_id do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-
-          if discriminator.authenticated_resource_matches_identity?
-            discriminator.controller.send(:test_track_visitor).id
-          else
-            identifier_value = send(identifier_value_method)
-            TestTrack::OfflineSession.with_visitor_for(identifier_type, identifier_value) do |v|
-              v.id
-            end
+          discriminator.test_track_visitor do |v|
+            v.id
           end
         end
 
         define_method :test_track_sign_up! do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
 
-          if discriminator.web_context?
-            identifier_value = send(identifier_value_method)
-            discriminator.controller.send(:test_track_session).sign_up! identifier_type, identifier_value
-          else
-            raise "test_track_sign_up! called outside of a web context"
-          end
+          identifier_value = send(identifier_value_method)
+          discriminator.test_track_session.sign_up! identifier_type, identifier_value
         end
 
         define_method :test_track_log_in! do |opts = {}|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
 
-          if discriminator.web_context?
-            identifier_value = send(identifier_value_method)
-            discriminator.controller.send(:test_track_session).log_in! identifier_type, identifier_value, opts
-          else
-            raise "test_track_log_in! called outside of a web context"
-          end
+          identifier_value = send(identifier_value_method)
+          discriminator.test_track_session.log_in! identifier_type, identifier_value, opts
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/PerceivedComplexity
   end
 end

--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -39,16 +39,14 @@ module TestTrack::Identity
         define_method :test_track_sign_up! do
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
           discriminator.with_session do |session|
-            identifier_value = send(identifier_value_method)
-            session.sign_up! identifier_type, identifier_value
+            session.sign_up! self
           end
         end
 
         define_method :test_track_log_in! do |opts = {}|
           discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
           discriminator.with_session do |session|
-            identifier_value = send(identifier_value_method)
-            session.log_in! identifier_type, identifier_value
+            session.log_in! self, opts
           end
         end
       end

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -8,7 +8,7 @@ class TestTrack::IdentitySessionDiscriminator
   def with_visitor
     raise ArgumentError, "must provide block to `with_visitor`" unless block_given?
 
-    if managed_identity?
+    if matching_identity?
       yield session.visitor_dsl
     else
       TestTrack::OfflineSession.with_visitor_for(identity.test_track_identifier_type, identity.test_track_identifier_value) do |v|
@@ -29,8 +29,8 @@ class TestTrack::IdentitySessionDiscriminator
 
   private
 
-  def managed_identity?
-    session.present? && session.managed_identity?(identity)
+  def matching_identity?
+    session.present? && session.has_matching_identity?(identity)
   end
 
   def web_context?

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -5,7 +5,7 @@ class TestTrack::IdentitySessionDiscriminator
     @identity = identity
   end
 
-  def test_track_visitor
+  def with_visitor
     if authenticated_resource_matches_identity?
       yield controller.send(:test_track_visitor)
     else
@@ -15,11 +15,11 @@ class TestTrack::IdentitySessionDiscriminator
     end
   end
 
-  def test_track_session
+  def with_session
     if web_context?
-      controller.send(:test_track_session)
+      yield controller.send(:test_track_session)
     else
-      raise "test_track_session called outside of a web context"
+      raise "with_session called outside of a web context"
     end
   end
 

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -6,8 +6,8 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   def with_visitor
-    if authenticated_resource_matches_identity?
-      yield controller.send(:test_track_visitor)
+    if managed_identity?
+      yield session.visitor_dsl
     else
       TestTrack::OfflineSession.with_visitor_for(identity.test_track_identifier_type, identity.test_track_identifier_value) do |v|
         yield v
@@ -17,23 +17,23 @@ class TestTrack::IdentitySessionDiscriminator
 
   def with_session
     if web_context?
-      yield controller.send(:test_track_session)
+      yield session
     else
-      raise "with_session called outside of a web context"
+      raise "#with_session called outside of web context"
     end
   end
 
   private
 
-  def authenticated_resource_matches_identity?
-    web_session.authenticated_resource_matches_identity?(identity)
+  def managed_identity?
+    session.managed_identity?(identity)
   end
 
   def web_context?
-    web_session.present?
+    session.present?
   end
 
-  def web_session
-    @web_session ||= RequestStore[:test_track_web_session]
+  def session
+    @session ||= RequestStore[:test_track_session]
   end
 end

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -6,6 +6,8 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   def with_visitor
+    raise ArgumentError, "must provide block to `with_visitor`" unless block_given?
+
     if managed_identity?
       yield session.visitor_dsl
     else
@@ -16,6 +18,8 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   def with_session
+    raise ArgumentError, "must provide block to `with_session`" unless block_given?
+
     if web_context?
       yield session
     else

--- a/app/models/test_track/identity_session_discriminator.rb
+++ b/app/models/test_track/identity_session_discriminator.rb
@@ -30,7 +30,7 @@ class TestTrack::IdentitySessionDiscriminator
   private
 
   def managed_identity?
-    session.managed_identity?(identity)
+    session.present? && session.managed_identity?(identity)
   end
 
   def web_context?

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -36,7 +36,7 @@ class TestTrack::Session
 
     @visitor = TestTrack::Visitor.new if opts[:forget_current_visitor]
     visitor.link_identifier!(identity.test_track_identifier_type, identity.test_track_identifier_value)
-    managed_identities << identity
+    matching_identities << identity
     self.mixpanel_distinct_id = visitor.id
     true
   end
@@ -45,13 +45,12 @@ class TestTrack::Session
     raise "must provide a TestTrack::Identity" unless identity.is_a?(TestTrack::Identity)
 
     visitor.link_identifier!(identity.test_track_identifier_type, identity.test_track_identifier_value)
-    managed_identities << identity
+    matching_identities << identity
     @signed_up = true
   end
 
-  def managed_identity?(identity)
-    managed_identity = managed_identities.find_by_identifier_type(identity)
-    managed_identity.present? && managed_identity == identity
+  def has_matching_identity?(identity)
+    matching_identities.include?(identity)
   end
 
   private
@@ -227,7 +226,7 @@ class TestTrack::Session
     end
   end
 
-  def managed_identities
-    @managed_identities ||= TestTrack::SessionIdentityCollection.new(controller)
+  def matching_identities
+    @matching_identities ||= TestTrack::SessionIdentityCollection.new(controller)
   end
 end

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -47,7 +47,7 @@ class TestTrack::Session
     @visitor = TestTrack::Visitor.new if opts[:forget_current_visitor]
     visitor.link_identifier!(identifier_type, identifier_value)
 
-    matching_identities << identity if identity.present?
+    identities << identity if identity.present?
     self.mixpanel_distinct_id = visitor.id
     true
   end
@@ -65,12 +65,12 @@ class TestTrack::Session
 
     visitor.link_identifier!(identifier_type, identifier_value)
 
-    matching_identities << identity if identity.present?
+    identities << identity if identity.present?
     @signed_up = true
   end
 
   def has_matching_identity?(identity)
-    matching_identities.include?(identity)
+    identities.include?(identity)
   end
 
   private
@@ -246,7 +246,7 @@ class TestTrack::Session
     end
   end
 
-  def matching_identities
-    @matching_identities ||= TestTrack::SessionIdentityCollection.new(controller)
+  def identities
+    @identities ||= TestTrack::SessionIdentityCollection.new(controller)
   end
 end

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -31,21 +31,41 @@ class TestTrack::Session
     }
   end
 
-  def log_in!(identity, opts = {})
-    raise "must provide a TestTrack::Identity" unless identity.is_a?(TestTrack::Identity)
+  def log_in!(*args) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    opts = args[-1].is_a?(Hash) ? args.pop : {}
+
+    if args[0].is_a?(TestTrack::Identity)
+      identity = args[0]
+      identifier_type = identity.test_track_identifier_type
+      identifier_value = identity.test_track_identifier_value
+    else
+      identifier_type = args[0]
+      identifier_value = args[1]
+      warn "#log_in! with two args is deprecated. Please provide a TestTrack::Identity"
+    end
 
     @visitor = TestTrack::Visitor.new if opts[:forget_current_visitor]
-    visitor.link_identifier!(identity.test_track_identifier_type, identity.test_track_identifier_value)
-    matching_identities << identity
+    visitor.link_identifier!(identifier_type, identifier_value)
+
+    matching_identities << identity if identity.present?
     self.mixpanel_distinct_id = visitor.id
     true
   end
 
-  def sign_up!(identity)
-    raise "must provide a TestTrack::Identity" unless identity.is_a?(TestTrack::Identity)
+  def sign_up!(*args) # rubocop:disable Metrics/MethodLength
+    if args[0].is_a?(TestTrack::Identity)
+      identity = args[0]
+      identifier_type = identity.test_track_identifier_type
+      identifier_value = identity.test_track_identifier_value
+    else
+      identifier_type = args[0]
+      identifier_value = args[1]
+      warn "#sign_up! with two args is deprecated. Please provide a TestTrack::Identity"
+    end
 
-    visitor.link_identifier!(identity.test_track_identifier_type, identity.test_track_identifier_value)
-    matching_identities << identity
+    visitor.link_identifier!(identifier_type, identifier_value)
+
+    matching_identities << identity if identity.present?
     @signed_up = true
   end
 

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -45,7 +45,7 @@ class TestTrack::Session
     @signed_up = true
   end
 
-  def authenticated_resource_matches_identity?(identity)
+  def authenticated_resource_matches_identity?(identity) # rubocop:disable Metrics/AbcSize
     if signed_up?
       signed_up_identifier_type == identity.test_track_identifier_type && signed_up_identifier_value == identity.test_track_identifier_value
     else

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -40,7 +40,20 @@ class TestTrack::Session
 
   def sign_up!(identifier_type, identifier_value)
     visitor.link_identifier!(identifier_type, identifier_value)
+    @signed_up_identifier_type = identifier_type
+    @signed_up_identifier_value = identifier_value
     @signed_up = true
+  end
+
+  def authenticated_resource_matches_identity?(identity)
+    if signed_up?
+      signed_up_identifier_type == identity.test_track_identifier_type && signed_up_identifier_value == identity.test_track_identifier_value
+    else
+      authenticated_resource_method_name = "current_#{identity.class.model_name.element}"
+
+      # pass true to `respond_to?` to include private methods
+      controller.respond_to?(authenticated_resource_method_name, true) && controller.send(authenticated_resource_method_name) == identity
+    end
   end
 
   private

--- a/app/models/test_track/session_identity_collection.rb
+++ b/app/models/test_track/session_identity_collection.rb
@@ -3,8 +3,9 @@ class TestTrack::SessionIdentityCollection
     @controller = controller
   end
 
-  def find_by_identifier_type(identity)
-    identities[identity.test_track_identifier_type] || authenticated_resource_for_identity(identity) || nil
+  def include?(identity)
+    found_identity = identities[identity.test_track_identifier_type] || authenticated_resource_for_identity(identity)
+    found_identity.present? && found_identity == identity
   end
 
   def <<(identity)

--- a/app/models/test_track/session_identity_collection.rb
+++ b/app/models/test_track/session_identity_collection.rb
@@ -1,0 +1,28 @@
+class TestTrack::SessionIdentityCollection
+  def initialize(controller)
+    @controller = controller
+  end
+
+  def find_by_identifier_type(identity)
+    identities[identity.test_track_identifier_type] || authenticated_resource_for_identity(identity) || nil
+  end
+
+  def <<(identity)
+    identities[identity.test_track_identifier_type] = identity
+  end
+
+  private
+
+  attr_reader :controller
+
+  def identities
+    @identities ||= {}
+  end
+
+  def authenticated_resource_for_identity(identity)
+    authenticated_resource_method_name = "current_#{identity.class.model_name.element}"
+
+    # pass true to `respond_to?` to include private methods
+    controller.respond_to?(authenticated_resource_method_name, true) && controller.send(authenticated_resource_method_name)
+  end
+end

--- a/spec/controllers/concerns/test_track/test_trackable_controller_spec.rb
+++ b/spec/controllers/concerns/test_track/test_trackable_controller_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe TestTrack::Controller do
     expect(response).to have_http_status(:no_content)
   end
 
-  it "stores the visitor in RequestStore" do
+  it "stores the session in RequestStore" do
     get :show, id: "1234"
-    expect(RequestStore).to have_received(:[]=).with(:test_track_controller, controller)
+    expect(RequestStore).to have_received(:[]=).with(:test_track_session, instance_of(TestTrack::Session))
   end
 end

--- a/spec/models/concerns/test_track/identity_spec.rb
+++ b/spec/models/concerns/test_track/identity_spec.rb
@@ -1,147 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe TestTrack::Identity do
-  TestTrack::ClownModel = Class.new do
-    include ActiveModel::Model
-    include TestTrack::Identity
-
-    test_track_identifier "clown_id", :id
-
-    def id
-      1234
-    end
-  end
-
-  let(:test_track_controller_class) do
-    Class.new(ApplicationController) { include TestTrack::Controller }
-  end
-
-  let(:test_track_controller) { test_track_controller_class.new }
-
-  subject { TestTrack::ClownModel.new }
+  subject { Clown.new(id: 1234) }
 
   describe ".test_track_identifier" do
-    let(:unsynced_assignments_notifier) { instance_double(TestTrack::UnsyncedAssignmentsNotifier, notify: true) }
-
-    before do
-      allow(TestTrack::OfflineSession).to receive(:with_visitor_for).and_call_original
-      allow(TestTrack::VisitorDSL).to receive(:new).and_call_original
-      allow(TestTrack::UnsyncedAssignmentsNotifier).to receive(:new).and_return(unsynced_assignments_notifier)
-      allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(
-        "blue_button" => { "true" => 0, "false" => 100 },
-        "side_dish" => { "soup" => 0, "salad" => 100 }
-      )
-    end
-
     context "#test_track_ab" do
-      context "in a web request" do
-        let(:visitor) { TestTrack::Visitor.new }
-        let(:visitor_dsl) { TestTrack::VisitorDSL.new(visitor) }
+      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, ab: false) }
 
-        before do
-          allow(RequestStore).to receive(:exist?).and_return(true)
-          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return(test_track_controller)
-          allow(test_track_controller).to receive(:test_track_visitor).and_return(visitor_dsl)
-          allow(visitor).to receive(:ab).and_call_original
-        end
-
-        it "returns the correct value" do
-          expect(subject.test_track_ab(:blue_button, context: :spec)).to be false
-        end
-
-        context "controller does not have a #current_* method" do
-          it "uses an offline session" do
-            subject.test_track_ab(:blue_button, context: :spec)
-            expect(TestTrack::OfflineSession).to have_received(:with_visitor_for)
-          end
-        end
-
-        context "controller has a #current_* method" do
-          let(:test_track_controller_class) do
-            Class.new(ApplicationController) do
-              include TestTrack::Controller
-
-              private # make current_clown_model private to better simulate real world scenario
-
-              def current_clown_model
-              end
-            end
-          end
-
-          context "current_* equals the subject" do
-            before do
-              allow(test_track_controller).to receive(:current_clown_model).and_return(subject)
-            end
-
-            it "does not create an offline session" do
-              subject.test_track_ab(:blue_button, context: :spec)
-              expect(TestTrack::OfflineSession).not_to have_received(:with_visitor_for)
-            end
-
-            it "forwards all arguments to the visitor correctly" do
-              subject.test_track_ab(:side_dish, true_variant: "soup", context: :spec)
-              expect(visitor).to have_received(:ab).with(:side_dish, true_variant: "soup", context: :spec)
-            end
-
-            it "does not send notifications inline" do
-              subject.test_track_ab(:blue_button, context: :spec)
-              expect(TestTrack::UnsyncedAssignmentsNotifier).not_to have_received(:new)
-            end
-
-            it "appends the assignment to the visitor's unsynced assignments" do
-              subject.test_track_ab(:blue_button, context: :spec)
-              visitor.unsynced_assignments.first.tap do |assignment|
-                expect(assignment.split_name).to eq("blue_button")
-                expect(assignment.variant).to eq("false")
-              end
-            end
-          end
-
-          context "current_* does not equal the subject" do
-            before do
-              allow(test_track_controller).to receive(:current_clown_model).and_return(TestTrack::ClownModel.new)
-            end
-
-            it "uses an offline session" do
-              subject.test_track_ab(:blue_button, context: :spec)
-              expect(TestTrack::OfflineSession).to have_received(:with_visitor_for)
-            end
-          end
-        end
+      before do
+        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
+        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      context "not in a web request" do
-        let(:visitor) { TestTrack::Visitor.new(id: "fake_visitor_id") }
+      it "delegates to the session discriminator" do
+        expect(subject.test_track_ab(:blue_button, context: :spec)).to be false
 
-        before do
-          allow(TestTrack::Visitor).to receive(:new).and_return(visitor)
-          allow(visitor).to receive(:ab).and_call_original
-        end
-
-        it "returns the correct value" do
-          expect(subject.test_track_ab(:blue_button, context: :spec)).to be false
-        end
-
-        it "forwards all arguments to the visitor correctly" do
-          subject.test_track_ab(:side_dish, true_variant: "soup", context: :spec)
-          expect(visitor).to have_received(:ab).with(:side_dish, true_variant: "soup", context: :spec)
-        end
-
-        it "creates an offline session" do
-          subject.test_track_ab :blue_button, context: :spec
-          expect(TestTrack::OfflineSession).to have_received(:with_visitor_for).with("clown_id", 1234)
-        end
-
-        it "sends notifications inline" do
-          subject.test_track_ab :blue_button, context: :spec
-          expect(TestTrack::UnsyncedAssignmentsNotifier).to have_received(:new) do |args|
-            expect(args[:visitor_id]).to eq("fake_visitor_id")
-            args[:assignments].first.tap do |assignment|
-              expect(assignment.split_name).to eq("blue_button")
-              expect(assignment.variant).to eq("false")
-            end
-          end
-        end
+        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
+        expect(identity_session_discriminator).to have_received(:with_visitor)
+        expect(visitor_dsl).to have_received(:ab).with(:blue_button, context: :spec)
       end
     end
 
@@ -153,167 +30,84 @@ RSpec.describe TestTrack::Identity do
         end
       end
 
-      context "in a web request" do
-        let(:visitor) { TestTrack::Visitor.new }
-        let(:visitor_dsl) { TestTrack::VisitorDSL.new(visitor) }
+      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, vary: "salad please") }
 
-        before do
-          allow(RequestStore).to receive(:exist?).and_return(true)
-          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return(test_track_controller)
-          allow(test_track_controller).to receive(:test_track_visitor).and_return(visitor_dsl)
-        end
-
-        it "returns the correct value" do
-          expect(vary_side_dish).to eq "salad please"
-        end
-
-        context "controller does not have a #current_* method" do
-          it "uses an offline session" do
-            vary_side_dish
-            expect(TestTrack::OfflineSession).to have_received(:with_visitor_for)
-          end
-        end
-
-        context "controller has a #current_* method" do
-          let(:test_track_controller_class) do
-            Class.new(ApplicationController) do
-              include TestTrack::Controller
-
-              private # make current_clown_model private to better simulate real world scenario
-
-              def current_clown_model
-              end
-            end
-          end
-
-          context "current_* equals the subject" do
-            before do
-              allow(test_track_controller).to receive(:current_clown_model).and_return(subject)
-            end
-
-            it "does not create an offline session" do
-              vary_side_dish
-              expect(TestTrack::OfflineSession).not_to have_received(:with_visitor_for)
-            end
-
-            it "does not send notifications inline" do
-              vary_side_dish
-              expect(TestTrack::UnsyncedAssignmentsNotifier).not_to have_received(:new)
-            end
-
-            it "appends the assignment to the visitor's unsynced assignments" do
-              vary_side_dish
-              visitor.unsynced_assignments.first.tap do |assignment|
-                expect(assignment.split_name).to eq("side_dish")
-                expect(assignment.variant).to eq("salad")
-              end
-            end
-          end
-
-          context "current_* does not equal the subject" do
-            before do
-              allow(test_track_controller).to receive(:current_clown_model).and_return(TestTrack::ClownModel.new)
-            end
-
-            it "uses an offline session" do
-              vary_side_dish
-              expect(TestTrack::OfflineSession).to have_received(:with_visitor_for)
-            end
-          end
-        end
+      before do
+        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
+        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      context "not in a web request" do
-        it "returns the correct value" do
-          expect(vary_side_dish).to eq "salad please"
-        end
+      it "delegates to the session discriminator" do
+        expect(vary_side_dish).to eq "salad please"
 
-        it "creates an offline session" do
-          vary_side_dish
-          expect(TestTrack::OfflineSession).to have_received(:with_visitor_for).with("clown_id", 1234)
-        end
-
-        it "sends notifications inline" do
-          vary_side_dish
-          expect(TestTrack::UnsyncedAssignmentsNotifier).to have_received(:new) do |args|
-            expect(args[:visitor_id]).to eq("fake_visitor_id")
-            args[:assignments].first.tap do |assignment|
-              expect(assignment.split_name).to eq("side_dish")
-              expect(assignment.variant).to eq("salad")
-            end
-          end
-        end
+        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
+        expect(identity_session_discriminator).to have_received(:with_visitor)
+        expect(visitor_dsl).to have_received(:vary).with(:side_dish, context: :spec)
       end
     end
 
     context "#test_track_visitor_id" do
-      context "in an offline session" do
-        it "returns the correct value" do
-          expect(subject.test_track_visitor_id).to eq 'fake_visitor_id'
-        end
+      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, id: "a_fake_id") }
+
+      before do
+        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
+        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      context "in a web context" do
-        let(:visitor) { TestTrack::Visitor.new }
-        let(:visitor_dsl) { TestTrack::VisitorDSL.new(visitor) }
-
-        before do
-          allow(RequestStore).to receive(:exist?).and_return true
-          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
-          allow(test_track_controller).to receive(:test_track_visitor).and_return visitor_dsl
-        end
-
-        it "returns the correct value" do
-          expect(subject.test_track_visitor_id).to eq 'fake_visitor_id'
-        end
+      it "returns the correct value from the session discriminator" do
+        expect(subject.test_track_visitor_id).to eq 'a_fake_id'
       end
     end
 
     context "#test_track_sign_up!" do
-      context "in an offline session" do
-        it "raises" do
-          expect { subject.test_track_sign_up! }.to raise_error /called outside of a web context/
-        end
+      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:session) { instance_double(TestTrack::Session) }
+
+      before do
+        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
+        allow(identity_session_discriminator).to receive(:with_session).and_yield(session)
+        allow(session).to receive(:sign_up!)
       end
 
-      context "in a web context" do
-        let(:session) { TestTrack::Session.new(test_track_controller) }
+      it "delegates to the session discriminator" do
+        subject.test_track_sign_up!
 
-        it "signs up using the online session" do
-          allow(RequestStore).to receive(:exist?).and_return true
-          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
-          allow(session).to receive(:sign_up!)
-          allow(test_track_controller).to receive(:test_track_session).and_return(session)
-
-          subject.test_track_sign_up!
-
-          expect(test_track_controller).to have_received(:test_track_session)
-          expect(session).to have_received(:sign_up!).with("clown_id", 1234)
-        end
+        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
+        expect(identity_session_discriminator).to have_received(:with_session)
+        expect(session).to have_received(:sign_up!).with(subject)
       end
     end
 
     context "#test_track_log_in!" do
-      context "in an offline session" do
-        it "raises" do
-          expect { subject.test_track_log_in! }.to raise_error /called outside of a web context/
-        end
+      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:session) { instance_double(TestTrack::Session) }
+
+      before do
+        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
+        allow(identity_session_discriminator).to receive(:with_session).and_yield(session)
+        allow(session).to receive(:log_in!)
       end
 
-      context "in a web context" do
-        let(:session) { TestTrack::Session.new(test_track_controller) }
+      it "delegates to the session discriminator" do
+        subject.test_track_log_in! some_args: 1234
 
-        it "signs up using the online session" do
-          allow(RequestStore).to receive(:exist?).and_return true
-          allow(RequestStore).to receive(:[]).with(:test_track_controller).and_return test_track_controller
-          allow(session).to receive(:log_in!)
-          allow(test_track_controller).to receive(:test_track_session).and_return(session)
+        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
+        expect(identity_session_discriminator).to have_received(:with_session)
+        expect(session).to have_received(:log_in!).with(subject, some_args: 1234)
+      end
+    end
 
-          subject.test_track_log_in!
+    context "#test_track_identifier_type" do
+      it "returns the configured identifier type" do
+        expect(subject.test_track_identifier_type).to eq "clown_id"
+      end
+    end
 
-          expect(test_track_controller).to have_received(:test_track_session)
-          expect(session).to have_received(:log_in!).with("clown_id", 1234, {})
-        end
+    context "#test_track_identifier_value" do
+      it "returns the model's identifier" do
+        expect(subject.test_track_identifier_value).to eq 1234
       end
     end
   end

--- a/spec/models/test_track/identity_session_discriminator_spec.rb
+++ b/spec/models/test_track/identity_session_discriminator_spec.rb
@@ -16,24 +16,24 @@ RSpec.describe TestTrack::IdentitySessionDiscriminator do
 
       before do
         allow(RequestStore).to receive(:[]).with(:test_track_session).and_return(test_track_session)
-        allow(test_track_session).to receive(:managed_identity?).and_return(session_manages_identity)
+        allow(test_track_session).to receive(:has_matching_identity?).and_return(has_matching_identity)
         allow(test_track_session).to receive(:visitor_dsl).and_return(visitor_dsl)
       end
 
-      context "when the session manages the identity" do
-        let(:session_manages_identity) { true }
+      context "when the session has a matching identity" do
+        let(:has_matching_identity) { true }
 
         it "yields the session's visitor dsl" do
           subject.with_visitor do |visitor|
             expect(visitor).to eq visitor_dsl
           end
 
-          expect(test_track_session).to have_received(:managed_identity?).with(identity)
+          expect(test_track_session).to have_received(:has_matching_identity?).with(identity)
         end
       end
 
-      context "when the session does not manage the identity" do
-        let(:session_manages_identity) { false }
+      context "when the session does not have a matching identity" do
+        let(:has_matching_identity) { false }
         let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL) }
 
         before do

--- a/spec/models/test_track/identity_session_discriminator_spec.rb
+++ b/spec/models/test_track/identity_session_discriminator_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe TestTrack::IdentitySessionDiscriminator do
+  let(:identity) { Clown.new(id: 1234) }
+
+  subject { TestTrack::IdentitySessionDiscriminator.new(identity) }
+
+  describe "#with_visitor" do
+    it "raises without a provided block" do
+      expect { subject.with_visitor }.to raise_exception /must provide block to `with_visitor`/
+    end
+
+    context "within a web context" do
+      let(:test_track_session) { instance_double(TestTrack::Session) }
+      let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL) }
+
+      before do
+        allow(RequestStore).to receive(:[]).with(:test_track_session).and_return(test_track_session)
+        allow(test_track_session).to receive(:managed_identity?).and_return(session_manages_identity)
+        allow(test_track_session).to receive(:visitor_dsl).and_return(visitor_dsl)
+      end
+
+      context "when the session manages the identity" do
+        let(:session_manages_identity) { true }
+
+        it "yields the session's visitor dsl" do
+          subject.with_visitor do |visitor|
+            expect(visitor).to eq visitor_dsl
+          end
+
+          expect(test_track_session).to have_received(:managed_identity?).with(identity)
+        end
+      end
+
+      context "when the session does not manage the identity" do
+        let(:session_manages_identity) { false }
+        let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL) }
+
+        before do
+          allow(TestTrack::OfflineSession).to receive(:with_visitor_for).and_yield(visitor_dsl)
+        end
+
+        it "creates an offline session and yields its visitor" do
+          subject.with_visitor do |visitor|
+            expect(visitor).to eq visitor_dsl
+          end
+
+          expect(TestTrack::OfflineSession).to have_received(:with_visitor_for).with("clown_id", 1234)
+        end
+      end
+    end
+
+    context "outside of a web context" do
+      let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL) }
+
+      before do
+        allow(TestTrack::OfflineSession).to receive(:with_visitor_for).and_yield(visitor_dsl)
+      end
+
+      it "creates an offline session and yields its visitor" do
+        subject.with_visitor do |visitor|
+          expect(visitor).to eq visitor_dsl
+        end
+
+        expect(TestTrack::OfflineSession).to have_received(:with_visitor_for).with("clown_id", 1234)
+      end
+    end
+  end
+
+  describe "#with_session" do
+    it "raises without a provided block" do
+      expect { subject.with_session }.to raise_exception /must provide block to `with_session`/
+    end
+
+    context "within a web context" do
+      let(:test_track_session) { instance_double(TestTrack::Session) }
+
+      before do
+        allow(RequestStore).to receive(:[]).with(:test_track_session).and_return(test_track_session)
+      end
+
+      it "yields the session" do
+        subject.with_session do |session|
+          expect(session).to eq test_track_session
+        end
+      end
+    end
+
+    context "outside of a web context" do
+      it "raises" do
+        expect { subject.with_session {} }.to raise_exception /#with_session called outside of web context/
+      end
+    end
+  end
+end

--- a/spec/models/test_track/session_identity_collection_spec.rb
+++ b/spec/models/test_track/session_identity_collection_spec.rb
@@ -13,45 +13,64 @@ RSpec.describe TestTrack::SessionIdentityCollection do
   end
 
   let(:controller) { controller_class.new }
-  let(:identity) { Clown.new(id: 1234) }
-  let(:other_identity) { Clown.new(id: 9876) }
+  let(:clown) { Clown.new(id: 1234) }
+  let(:other_clown) { Clown.new(id: 9876) }
+  let(:magician) { Magician.new(id: 1234) }
 
   subject { described_class.new(controller) }
 
   describe "#<<" do
     it "adds the identity to its collection" do
-      subject << identity
-      expect(subject.find_by_identifier_type(identity)).to eq identity
+      subject << clown
+      expect(subject.include?(clown)).to eq true
     end
 
     it "keeps the latest added identity for a given identifier type" do
-      subject << identity
-      subject << other_identity
-      expect(subject.find_by_identifier_type(identity)).to eq other_identity
+      subject << clown
+      subject << other_clown
+      subject << magician
+      expect(subject.include?(clown)).to eq false
+      expect(subject.include?(other_clown)).to eq true
+      expect(subject.include?(magician)).to eq true
     end
   end
 
-  describe "#find_by_identifier_type" do
+  describe "#include?" do
     context "when the controller has an authenticated resource for the identity type" do
       before do
-        allow(controller).to receive(:current_clown).and_return(identity)
+        allow(controller).to receive(:current_clown).and_return(clown)
       end
 
-      it "return the controller's resource" do
-        expect(subject.find_by_identifier_type(identity)).to eq identity
+      it "return true" do
+        expect(subject.include?(clown)).to eq true
       end
 
-      context "when a previously added identity matches the given type" do
-        it "returns the previously added identity" do
-          subject << other_identity
-          expect(subject.find_by_identifier_type(identity)).to eq other_identity
+      context "when another identity of the same type is added" do
+        before do
+          subject << other_clown
+        end
+
+        it "returns true for only the most recently added identity" do
+          expect(subject.include?(clown)).to eq false
+          expect(subject.include?(other_clown)).to eq true
+        end
+      end
+
+      context "when an identity of a different type is added" do
+        before do
+          subject << magician
+        end
+
+        it "returns true when " do
+          expect(subject.include?(clown)).to eq true
+          expect(subject.include?(magician)).to eq true
         end
       end
     end
 
     context "when no identity has been added" do
-      it "returns nil" do
-        expect(subject.find_by_identifier_type(identity)).to eq nil
+      it "returns false" do
+        expect(subject.include?(clown)).to eq false
       end
     end
   end

--- a/spec/models/test_track/session_identity_collection_spec.rb
+++ b/spec/models/test_track/session_identity_collection_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe TestTrack::SessionIdentityCollection do
+  let(:controller_class) do
+    Class.new(ApplicationController) do
+      include TestTrack::Controller
+
+      private # make current_clown private to better simulate real world scenario
+
+      def current_clown
+      end
+    end
+  end
+
+  let(:controller) { controller_class.new }
+  let(:identity) { Clown.new(id: 1234) }
+  let(:other_identity) { Clown.new(id: 9876) }
+
+  subject { described_class.new(controller) }
+
+  describe "#<<" do
+    it "adds the identity to its collection" do
+      subject << identity
+      expect(subject.find_by_identifier_type(identity)).to eq identity
+    end
+
+    it "keeps the latest added identity for a given identifier type" do
+      subject << identity
+      subject << other_identity
+      expect(subject.find_by_identifier_type(identity)).to eq other_identity
+    end
+  end
+
+  describe "#find_by_identifier_type" do
+    context "when the controller has an authenticated resource for the identity type" do
+      before do
+        allow(controller).to receive(:current_clown).and_return(identity)
+      end
+
+      it "return the controller's resource" do
+        expect(subject.find_by_identifier_type(identity)).to eq identity
+      end
+
+      context "when a previously added identity matches the given type" do
+        it "returns the previously added identity" do
+          subject << other_identity
+          expect(subject.find_by_identifier_type(identity)).to eq other_identity
+        end
+      end
+    end
+
+    context "when no identity has been added" do
+      it "returns nil" do
+        expect(subject.find_by_identifier_type(identity)).to eq nil
+      end
+    end
+  end
+end

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -569,14 +569,14 @@ RSpec.describe TestTrack::Session do
     end
   end
 
-  describe "#managed_identity?" do
+  describe "#has_matching_identity?" do
     context "when the controller's authenticated resource matches the identity" do
       before do
         allow(controller).to receive(:current_clown).and_return(identity)
       end
 
       it "returns true" do
-        expect(subject.managed_identity?(identity)).to eq true
+        expect(subject.has_matching_identity?(identity)).to eq true
       end
     end
 
@@ -588,27 +588,27 @@ RSpec.describe TestTrack::Session do
       end
 
       it "returns false" do
-        expect(subject.managed_identity?(identity)).to eq false
+        expect(subject.has_matching_identity?(identity)).to eq false
       end
     end
 
     context "when the identity matches a previously logged in identity" do
       it "returns true" do
-        expect(subject.managed_identity?(identity)).to eq false
+        expect(subject.has_matching_identity?(identity)).to eq false
 
         subject.log_in!(identity)
 
-        expect(subject.managed_identity?(identity)).to eq true
+        expect(subject.has_matching_identity?(identity)).to eq true
       end
     end
 
     context "when the identity matches a previously signed up identity" do
       it "returns true" do
-        expect(subject.managed_identity?(identity)).to eq false
+        expect(subject.has_matching_identity?(identity)).to eq false
 
         subject.sign_up!(identity)
 
-        expect(subject.managed_identity?(identity)).to eq true
+        expect(subject.has_matching_identity?(identity)).to eq true
       end
     end
   end

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -118,11 +118,16 @@ RSpec.describe TestTrack::Session do
       end
 
       context "forget current visitor" do
+        before do
+          allow(TestTrack::Visitor).to receive(:new).and_call_original
+        end
+
         it "creates a temporary visitor when creating the identifier" do
           subject.manage do
             subject.log_in!(identity, forget_current_visitor: true)
           end
 
+          expect(TestTrack::Visitor).to have_received(:new)
           expect(TestTrack::Remote::Identifier).to have_received(:create!).with(
             identifier_type: "clown_id",
             visitor_id: /\A[a-f0-9\-]{36}\z/,
@@ -543,8 +548,10 @@ RSpec.describe TestTrack::Session do
       expect(subject.log_in!(identity)).to eq true
     end
 
-    it "requires an identity" do
-      expect { subject.sign_up!('identity_type', 'identity_value') }.to raise_exception //
+    it "allows identity type and value arguments with a warning" do
+      expect do
+        subject.log_in!('identity_type', 'identity_value')
+      end.to output(/#log_in! with two args is deprecated. Please provide a TestTrack::Identity/).to_stderr
     end
   end
 
@@ -564,8 +571,10 @@ RSpec.describe TestTrack::Session do
       expect(subject.sign_up!(identity)).to eq true
     end
 
-    it "requires an identity" do
-      expect { subject.sign_up!('identity_type', 'identity_value') }.to raise_exception //
+    it "allows identity type and value arguments with a warning" do
+      expect do
+        subject.sign_up!('identity_type', 'identity_value')
+      end.to output(/#sign_up! with two args is deprecated. Please provide a TestTrack::Identity/).to_stderr
     end
   end
 

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -1,7 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe TestTrack::Session do
-  let(:controller) { instance_double(ApplicationController, cookies: cookies, request: request, response: response) }
+  let(:identity) { Clown.new(id: 1234) }
+
+  let(:controller_class) do
+    Class.new(ApplicationController) do
+      include TestTrack::Controller
+
+      private # make current_clown private to better simulate real world scenario
+
+      def current_clown
+      end
+    end
+  end
+
+  let(:controller) { controller_class.new }
+
   let(:cookies) { { tt_visitor_id: "fake_visitor_id", mp_fakefakefake_mixpanel: mixpanel_cookie }.with_indifferent_access }
   let(:headers) { {} }
   let(:mixpanel_cookie) { { distinct_id: "fake_distinct_id", OtherProperty: "bar" }.to_json }
@@ -12,6 +26,9 @@ RSpec.describe TestTrack::Session do
   subject { described_class.new(controller) }
 
   before do
+    allow(controller).to receive(:cookies).and_return(cookies)
+    allow(controller).to receive(:request).and_return(request)
+    allow(controller).to receive(:response).and_return(response)
     allow(TestTrack::UnsyncedAssignmentsNotifier).to receive(:new).and_return(unsynced_assignments_notifier)
     allow(Thread).to receive(:new).and_call_original
     allow(TestTrack::CreateAliasJob).to receive(:new).and_call_original
@@ -44,19 +61,19 @@ RSpec.describe TestTrack::Session do
 
       it "provides the current visitor id when requesting an identifier" do
         subject.manage do
-          subject.log_in!("identifier_type", "value")
+          subject.log_in!(identity)
 
           expect(TestTrack::Remote::Identifier).to have_received(:create!).with(
-            identifier_type: "identifier_type",
+            identifier_type: "clown_id",
             visitor_id: "fake_visitor_id",
-            value: "value"
+            value: "1234"
           )
         end
       end
 
       it "sets correct tt_visitor_id" do
         subject.manage do
-          subject.log_in!("identifier_type", "value")
+          subject.log_in!(identity)
         end
         expect(cookies['tt_visitor_id'][:value]).to eq "real_visitor_id"
       end
@@ -70,7 +87,7 @@ RSpec.describe TestTrack::Session do
 
         it "does not return the visitor id in the reponse header" do
           subject.manage do
-            subject.log_in!("identifier_type", "value")
+            subject.log_in!(identity)
           end
 
           expect(controller.response.headers).not_to have_key('X-Set-TT-Visitor-ID')
@@ -86,7 +103,7 @@ RSpec.describe TestTrack::Session do
 
         it "returns the existing visitor id in the reponse header" do
           subject.manage do
-            subject.log_in!("identifier_type", "value")
+            subject.log_in!(identity)
           end
 
           expect(controller.response.headers['X-Set-TT-Visitor-ID']).to eq('real_visitor_id')
@@ -95,7 +112,7 @@ RSpec.describe TestTrack::Session do
 
       it "changes the distinct_id in the mixpanel cookie" do
         subject.manage do
-          subject.log_in!("identifier_type", "value")
+          subject.log_in!(identity)
         end
         expect(cookies['mp_fakefakefake_mixpanel'][:value]).to eq({ distinct_id: "real_visitor_id", OtherProperty: "bar" }.to_json)
       end
@@ -103,13 +120,13 @@ RSpec.describe TestTrack::Session do
       context "forget current visitor" do
         it "creates a temporary visitor when creating the identifier" do
           subject.manage do
-            subject.log_in!("identifier_type", "value", forget_current_visitor: true)
+            subject.log_in!(identity, forget_current_visitor: true)
           end
 
           expect(TestTrack::Remote::Identifier).to have_received(:create!).with(
-            identifier_type: "identifier_type",
+            identifier_type: "clown_id",
             visitor_id: /\A[a-f0-9\-]{36}\z/,
-            value: "value"
+            value: "1234"
           )
         end
       end
@@ -128,12 +145,12 @@ RSpec.describe TestTrack::Session do
       describe '#sign_up!' do
         it "provides the current visitor id when requesting an identifier" do
           subject.manage do
-            subject.sign_up!("identifier_type", "value")
+            subject.sign_up!(identity)
 
             expect(TestTrack::Remote::Identifier).to have_received(:create!).with(
-              identifier_type: "identifier_type",
+              identifier_type: "clown_id",
               visitor_id: "fake_visitor_id",
-              value: "value"
+              value: "1234"
             )
           end
         end
@@ -142,12 +159,12 @@ RSpec.describe TestTrack::Session do
       describe '#log_in!' do
         it "provides the current visitor id when requesting an identifier" do
           subject.manage do
-            subject.log_in!("identifier_type", "value")
+            subject.log_in!(identity)
 
             expect(TestTrack::Remote::Identifier).to have_received(:create!).with(
-              identifier_type: "identifier_type",
+              identifier_type: "clown_id",
               visitor_id: "fake_visitor_id",
-              value: "value"
+              value: "1234"
             )
           end
         end
@@ -405,7 +422,7 @@ RSpec.describe TestTrack::Session do
         )
 
         subject.manage do
-          subject.sign_up!('myappdb_user_id', 444)
+          subject.sign_up!(identity)
         end
 
         expect(Delayed::Job).to have_received(:enqueue).with(an_instance_of(TestTrack::CreateAliasJob))
@@ -518,12 +535,16 @@ RSpec.describe TestTrack::Session do
     end
 
     it "calls link_identifier! on the visitor" do
-      subject.log_in!('myappdb_user_id', 444)
-      expect(visitor).to have_received(:link_identifier!).with('myappdb_user_id', 444)
+      subject.log_in!(identity)
+      expect(visitor).to have_received(:link_identifier!).with('clown_id', 1234)
     end
 
     it "returns true" do
-      expect(subject.log_in!('myappdb_user_id', 444)).to eq true
+      expect(subject.log_in!(identity)).to eq true
+    end
+
+    it "requires an identity" do
+      expect { subject.sign_up!('identity_type', 'identity_value') }.to raise_exception //
     end
   end
 
@@ -535,12 +556,60 @@ RSpec.describe TestTrack::Session do
     end
 
     it "calls link_identifier! on the visitor" do
-      subject.sign_up!('myappdb_user_id', 444)
-      expect(visitor).to have_received(:link_identifier!).with('myappdb_user_id', 444)
+      subject.sign_up!(identity)
+      expect(visitor).to have_received(:link_identifier!).with('clown_id', 1234)
     end
 
     it "returns true" do
-      expect(subject.sign_up!('myappdb_user_id', 444)).to eq true
+      expect(subject.sign_up!(identity)).to eq true
+    end
+
+    it "requires an identity" do
+      expect { subject.sign_up!('identity_type', 'identity_value') }.to raise_exception //
+    end
+  end
+
+  describe "#managed_identity?" do
+    context "when the controller's authenticated resource matches the identity" do
+      before do
+        allow(controller).to receive(:current_clown).and_return(identity)
+      end
+
+      it "returns true" do
+        expect(subject.managed_identity?(identity)).to eq true
+      end
+    end
+
+    context "when the controller's authenticated resource does not match the identity" do
+      let(:other_identity) { Clown.new(id: 9876) }
+
+      before do
+        allow(controller).to receive(:current_clown).and_return(other_identity)
+      end
+
+      it "returns false" do
+        expect(subject.managed_identity?(identity)).to eq false
+      end
+    end
+
+    context "when the identity matches a previously logged in identity" do
+      it "returns true" do
+        expect(subject.managed_identity?(identity)).to eq false
+
+        subject.log_in!(identity)
+
+        expect(subject.managed_identity?(identity)).to eq true
+      end
+    end
+
+    context "when the identity matches a previously signed up identity" do
+      it "returns true" do
+        expect(subject.managed_identity?(identity)).to eq false
+
+        subject.sign_up!(identity)
+
+        expect(subject.managed_identity?(identity)).to eq true
+      end
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,8 +59,6 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  config.before(:each) { RequestStore.clear! }
-
   config.include EnvironmentSpecHelper
   config.include EnabledSpecHelper
   config.include DelayedJobSpecHelper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
+  config.before(:each) { RequestStore.clear! }
+
   config.include EnvironmentSpecHelper
   config.include EnabledSpecHelper
   config.include DelayedJobSpecHelper

--- a/spec/support/fakes/clown.rb
+++ b/spec/support/fakes/clown.rb
@@ -1,0 +1,8 @@
+class Clown
+  include ActiveModel::Model
+  include TestTrack::Identity
+
+  test_track_identifier "clown_id", :id
+
+  attr_accessor :id
+end

--- a/spec/support/fakes/magician.rb
+++ b/spec/support/fakes/magician.rb
@@ -1,0 +1,8 @@
+class Magician
+  include ActiveModel::Model
+  include TestTrack::Identity
+
+  test_track_identifier "magician_id", :id
+
+  attr_accessor :id
+end


### PR DESCRIPTION
/domain @samandmoore @jmileham @ceslami 
/no-platform
/cc @joejansen @chrislopresto 

This addresses a performance problem in sign up requests (and for logins too). After calling `test_track_sign_up!`, subsequent `vary` calls on the signed up identity will use an offline session, even though the main session could be used (since it's visitor now has that identity). Using an offline session means at least one, possibly two, additional remote calls per `vary`.

This changeset modifies `TestTrack::Session` to keep track of signed up and logged in identities, so the session discriminator can use the main session if its operating on one of those identities. I also cleaned up the Identity mixin a bit, so it delegates more to the discriminator.

This is a breaking change on `TT::Session`, so we'll have to bump the major version number. I could make this backwards compatible, but the upgrade path is pretty straightforward.

TODO
- [x] Update specs
- [x] Add an `UPGRADING` section to the readme