### PR TITLE
Loosen public suffix constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-- 1.9.3
 - jruby-9.1.9.0-d19
 - 2.0.0
 - 2.3.1

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -123,7 +123,7 @@ class TestTrack::Session
   end
 
   def public_suffix_host
-    @public_suffix_host ||= PublicSuffix.parse(request.host)
+    @public_suffix_host ||= PublicSuffix.parse(request.host, default_rule: nil)
   end
 
   def manage_cookies!

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 4.1', "< 6.0"
   s.add_dependency "faraday", ">= 0.8", "< 1.0"
   s.add_dependency 'faraday_middleware'
-  s.add_dependency 'public_suffix', '~> 1.4.6'
+  s.add_dependency 'public_suffix', '>= 1.4.6', '< 4.0'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
   s.add_dependency 'delayed_job', '~> 4.0'
   s.add_dependency 'delayed_job_active_record'

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 4.1', "< 6.0"
   s.add_dependency "faraday", ">= 0.8", "< 1.0"
   s.add_dependency 'faraday_middleware'
-  s.add_dependency 'public_suffix', '>= 1.4.6', '< 4.0'
+  s.add_dependency 'public_suffix', '>= 2.0.0', '<= 3.0.0'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
   s.add_dependency 'delayed_job', '~> 4.0'
   s.add_dependency 'delayed_job_active_record'

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop", ">= 0.36"
   s.add_development_dependency "webmock", "~> 2.1.0"
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 end


### PR DESCRIPTION
/domain @samandmoore @jmileham 
/platform @samandmoore @jmileham 

TestTrack's public_suffix dependency is outdated, and the version constraint on it is more restrictive than it probably needs to be. 

The largest behavior change in public_suffix 2+ is that lookups now default to a "wildcard" rule, for validations, which is much more permissive in the domains that it allows. The old behavior is preserved here by using the `default_rule: nil` argument to `PublicSuffix.parse`. 

Upgrading public suffix also requires dropping compatibility for ruby versions < 2.0. 