### PR TITLE
add a warning notification message for calling vary with the same var…

### DIFF
--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -57,6 +57,10 @@ class TestTrack::VaryDSL
     variant = variant.to_s
 
     raise ArgumentError, "must provide block for #{variant}" unless behavior_proc
+    notify_because_vary(<<-MESSAGE) if variant_behaviors.include?(variant)
+      configures variant "#{variant}" more than once.
+      This will raise an error in the next version of test_track_rails_client.
+    MESSAGE
     notify_because_vary "configures unknown variant \"#{variant}\"" unless variant_acceptable?(variant)
 
     variant_behaviors[variant] = behavior_proc

--- a/spec/models/test_track/vary_dsl_spec.rb
+++ b/spec/models/test_track/vary_dsl_spec.rb
@@ -169,11 +169,20 @@ RSpec.describe TestTrack::VaryDSL do
         expect(notifier).not_to have_received(:notify)
       end
     end
+
+    context "when adding a variant that was already configured" do
+      it "tells airbrake" do
+        subject.when :one, &noop
+        subject.when :one, &noop
+        expect(notifier).to have_received(:notify)
+          .with(/configures variant "one" more than once/)
+      end
+    end
   end
 
   context "#default" do
     it "accepts a block" do
-      subject.when :one do
+      subject.default :one do
         puts "hello"
       end
 
@@ -187,6 +196,16 @@ RSpec.describe TestTrack::VaryDSL do
 
       expect(notifier).to have_received(:notify)
         .with('vary for "button_size" configures unknown variant "this_default_does_not_exist"')
+    end
+
+    context "when adding a default for a variant that was already configured" do
+      it "tells airbrake" do
+        subject.when :one, &noop
+        subject.default :one, &noop
+
+        expect(notifier).to have_received(:notify)
+          .with(/configures variant "one" more than once/)
+      end
     end
 
     context "with a nil split_registry" do


### PR DESCRIPTION
/domain @samandmoore @aburgel @while1malloc0 @agirlnamedsophia 
/no-platform

Implementing this! https://github.com/Betterment/test_track_rails_client/issues/8

I figured we should start with a notify, and if this is live for a while without any issues, we can turn it into a raise.

I decided to implement this issue slightly more broadly: you should never run into a scenario where you need to define the same variant twice whether in `when` or `default`.