### PR TITLE
Don't sync assignment events for gates

### DIFF
--- a/app/models/test_track/analytics/mixpanel_client.rb
+++ b/app/models/test_track/analytics/mixpanel_client.rb
@@ -1,7 +1,7 @@
 module TestTrack::Analytics
   class MixpanelClient
     def track_assignment(visitor_id, assignment)
-      mixpanel.track(visitor_id, 'SplitAssigned', split_properties(assignment).merge(TTVisitorID: visitor_id))
+      mixpanel.track(visitor_id, event_name(assignment), split_properties(assignment).merge(TTVisitorID: visitor_id))
     end
 
     private
@@ -9,6 +9,14 @@ module TestTrack::Analytics
     def mixpanel
       raise "ENV['MIXPANEL_TOKEN'] must be set" unless ENV['MIXPANEL_TOKEN']
       @mixpanel ||= Mixpanel::Tracker.new(ENV['MIXPANEL_TOKEN'])
+    end
+
+    def event_name(assignment)
+      if assignment.feature_gate?
+        'FeatureGateExperienced'
+      else
+        'SplitAssigned'
+      end
     end
 
     def split_properties(assignment)

--- a/app/models/test_track/analytics/mixpanel_client.rb
+++ b/app/models/test_track/analytics/mixpanel_client.rb
@@ -1,7 +1,7 @@
 module TestTrack::Analytics
   class MixpanelClient
-    def track_assignment(visitor_id, assignment)
-      mixpanel.track(visitor_id, event_name(assignment), split_properties(assignment).merge(TTVisitorID: visitor_id))
+    def track(analytics_event)
+      mixpanel.track(analytics_event.visitor_id, analytics_event.name, analytics_event.properties)
     end
 
     private
@@ -9,22 +9,6 @@ module TestTrack::Analytics
     def mixpanel
       raise "ENV['MIXPANEL_TOKEN'] must be set" unless ENV['MIXPANEL_TOKEN']
       @mixpanel ||= Mixpanel::Tracker.new(ENV['MIXPANEL_TOKEN'])
-    end
-
-    def event_name(assignment)
-      if assignment.feature_gate?
-        'FeatureGateExperienced'
-      else
-        'SplitAssigned'
-      end
-    end
-
-    def split_properties(assignment)
-      {
-        SplitName: assignment.split_name,
-        SplitVariant: assignment.variant,
-        SplitContext: assignment.context
-      }
     end
   end
 end

--- a/app/models/test_track/analytics/safe_wrapper.rb
+++ b/app/models/test_track/analytics/safe_wrapper.rb
@@ -12,8 +12,8 @@ module TestTrack::Analytics
       @error_handler = handler
     end
 
-    def track_assignment(visitor_id, assignment)
-      safe_action { underlying.track_assignment(visitor_id, assignment) }
+    def track(analytics_event)
+      safe_action { underlying.track(analytics_event) }
     end
 
     def sign_up!(visitor_id)

--- a/app/models/test_track/analytics_event.rb
+++ b/app/models/test_track/analytics_event.rb
@@ -1,0 +1,28 @@
+module TestTrack
+  class AnalyticsEvent
+    attr_reader :assignment
+
+    delegate :visitor_id, to: :assignment
+
+    def initialize(assignment)
+      @assignment = assignment
+    end
+
+    def name
+      if assignment.feature_gate?
+        'FeatureGateExperienced'
+      else
+        'SplitAssigned'
+      end
+    end
+
+    def properties
+      {
+        TTVisitorID: visitor_id,
+        SplitName: assignment.split_name,
+        SplitVariant: assignment.variant,
+        SplitContext: assignment.context
+      }
+    end
+  end
+end

--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -16,7 +16,11 @@ class TestTrack::Assignment
   end
 
   def unsynced?
-    true
+    !feature_gate?
+  end
+
+  def feature_gate?
+    split_name.end_with?('_enabled')
   end
 
   private

--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -23,6 +23,14 @@ class TestTrack::Assignment
     split_name.end_with?('_enabled')
   end
 
+  def analytics_event
+    @analytics_event ||= AnalyticsEvent.new(self)
+  end
+
+  def visitor_id
+    visitor.id
+  end
+
   private
 
   def _variant

--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -16,7 +16,7 @@ class TestTrack::Assignment
   end
 
   def unsynced?
-    !feature_gate?
+    true
   end
 
   def feature_gate?

--- a/app/models/test_track/fake/visitor.rb
+++ b/app/models/test_track/fake/visitor.rb
@@ -1,7 +1,7 @@
 class TestTrack::Fake::Visitor
   attr_reader :id
 
-  Assignment = Struct.new(:split_name, :variant, :unsynced, :context)
+  Assignment = Struct.new(:split_name, :variant, :unsynced, :context, :visitor_id)
 
   def self.instance
     @instance ||= new(TestTrack::FakeServer.seed)
@@ -28,7 +28,7 @@ class TestTrack::Fake::Visitor
   def _assignments
     split_registry.keys.map do |split_name|
       variant = TestTrack::VariantCalculator.new(visitor: self, split_name: split_name).variant
-      Assignment.new(split_name, variant, false, "the_context")
+      Assignment.new(split_name, variant, false, "the_context", id)
     end
   end
 end

--- a/app/models/test_track/notify_assignment_job.rb
+++ b/app/models/test_track/notify_assignment_job.rb
@@ -12,12 +12,15 @@ class TestTrack::NotifyAssignmentJob
   end
 
   def perform
-    TestTrack::Remote::AssignmentEvent.create!(
-      visitor_id: visitor_id,
-      split_name: assignment.split_name,
-      context: assignment.context,
-      mixpanel_result: track
-    )
+    tracking_result = track
+    unless assignment.feature_gate?
+      TestTrack::Remote::AssignmentEvent.create!(
+        visitor_id: visitor_id,
+        split_name: assignment.split_name,
+        context: assignment.context,
+        mixpanel_result: tracking_result
+      )
+    end
   end
 
   private

--- a/app/models/test_track/notify_assignment_job.rb
+++ b/app/models/test_track/notify_assignment_job.rb
@@ -27,7 +27,7 @@ class TestTrack::NotifyAssignmentJob
 
   def track
     return "failure" unless TestTrack.enabled?
-    result = TestTrack.analytics.track_assignment(visitor_id, assignment)
+    result = TestTrack.analytics.track(assignment.analytics_event)
     result ? "success" : "failure"
   end
 end

--- a/spec/models/test_track/analytics/mixpanel_client_spec.rb
+++ b/spec/models/test_track/analytics/mixpanel_client_spec.rb
@@ -3,17 +3,14 @@ require 'rails_helper'
 RSpec.describe TestTrack::Analytics::MixpanelClient do
   subject { TestTrack::Analytics::MixpanelClient.new }
 
-  describe "#track_assignment" do
+  describe "#track" do
     let(:mixpanel) { instance_double(Mixpanel::Tracker, track: true) }
-    let(:feature_gate) { false }
-    let(:assignment) do
+    let(:analytics_event) do
       instance_double(
-        TestTrack::Assignment,
-        visitor: 123,
-        split_name: "foo",
-        variant: "true",
-        context: "bar",
-        feature_gate?: feature_gate
+        TestTrack::AnalyticsEvent,
+        visitor_id: 123,
+        name: "SplitAssigned",
+        properties: split_properties
       )
     end
     let(:split_properties) do
@@ -31,20 +28,20 @@ RSpec.describe TestTrack::Analytics::MixpanelClient do
     end
 
     it "configures mixpanel with the token" do
-      subject.track_assignment(123, assignment)
+      subject.track(analytics_event)
 
       expect(Mixpanel::Tracker).to have_received(:new).with('fakefakefake')
     end
 
     it "calls mixpanel track" do
-      subject.track_assignment(123, assignment)
+      subject.track(analytics_event)
 
       expect(mixpanel).to have_received(:track).with(123, 'SplitAssigned', split_properties)
     end
 
     it "raises if mixpanel track raises Mixpanel::ConnectionError" do
       allow(mixpanel).to receive(:track) { raise Mixpanel::ConnectionError.new, "Womp womp" }
-      expect { subject.track_assignment(123, assignment) }.to raise_error Mixpanel::ConnectionError, /Womp womp/
+      expect { subject.track(analytics_event) }.to raise_error Mixpanel::ConnectionError, /Womp womp/
     end
 
     it "raises if mixpanel track fails" do
@@ -53,19 +50,9 @@ RSpec.describe TestTrack::Analytics::MixpanelClient do
       allow(Mixpanel::Tracker).to receive(:new).and_call_original
       stub_request(:post, 'https://api.mixpanel.com/track').to_return(status: 500, body: "")
 
-      expect { subject.track_assignment(123, assignment) }.to raise_error Mixpanel::ConnectionError
+      expect { subject.track(analytics_event) }.to raise_error Mixpanel::ConnectionError
 
       expect(WebMock).to have_requested(:post, 'https://api.mixpanel.com/track')
-    end
-
-    context "with a feature gate" do
-      let(:feature_gate) { true }
-
-      it "tracks a FeatureGateExperienced event instead" do
-        subject.track_assignment(123, assignment)
-
-        expect(mixpanel).to have_received(:track).with(123, 'FeatureGateExperienced', split_properties)
-      end
     end
   end
 end

--- a/spec/models/test_track/analytics/safe_wrapper_spec.rb
+++ b/spec/models/test_track/analytics/safe_wrapper_spec.rb
@@ -3,20 +3,22 @@ require 'rails_helper'
 RSpec.describe TestTrack::Analytics::SafeWrapper do
   let(:underlying) { double("Client", track: true, sign_up!: true) }
 
+  let(:event) { instance_double(TestTrack::AnalyticsEvent) }
+
   subject { TestTrack::Analytics::SafeWrapper.new(underlying) }
 
   describe '#track' do
     it 'calls underlying' do
-      expect(subject.track("my event")).to eq true
-      expect(underlying).to have_received(:track).with("my event")
+      expect(subject.track(event)).to eq true
+      expect(underlying).to have_received(:track).with(event)
     end
 
     context 'underlying raises' do
       it 'returns false' do
         allow(underlying).to receive(:track).and_raise StandardError
 
-        expect(subject.track("my event")).to eq false
-        expect(underlying).to have_received(:track).with("my event")
+        expect(subject.track(event)).to eq false
+        expect(underlying).to have_received(:track).with(event)
       end
     end
   end
@@ -60,7 +62,7 @@ RSpec.describe TestTrack::Analytics::SafeWrapper do
     end
 
     it 'logs error to Rails.logger' do
-      subject.track("my event")
+      subject.track(event)
 
       expect(Rails.logger).to have_received(:error).with(error)
     end
@@ -75,7 +77,7 @@ RSpec.describe TestTrack::Analytics::SafeWrapper do
       end
 
       it 'uses custom lambda' do
-        subject.track("my event")
+        subject.track(event)
 
         expect(handler).to have_received(:call).with(error)
       end

--- a/spec/models/test_track/analytics/safe_wrapper_spec.rb
+++ b/spec/models/test_track/analytics/safe_wrapper_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe TestTrack::Analytics::SafeWrapper do
-  let(:underlying) { double("Client", track_assignment: true, sign_up!: true) }
+  let(:underlying) { double("Client", track: true, sign_up!: true) }
 
   subject { TestTrack::Analytics::SafeWrapper.new(underlying) }
 
-  describe '#track_assignment' do
+  describe '#track' do
     it 'calls underlying' do
-      expect(subject.track_assignment(123, foo: "bar")).to eq true
-      expect(underlying).to have_received(:track_assignment).with(123, foo: "bar")
+      expect(subject.track("my event")).to eq true
+      expect(underlying).to have_received(:track).with("my event")
     end
 
     context 'underlying raises' do
       it 'returns false' do
-        allow(underlying).to receive(:track_assignment).and_raise StandardError
+        allow(underlying).to receive(:track).and_raise StandardError
 
-        expect(subject.track_assignment(123, {})).to eq false
-        expect(underlying).to have_received(:track_assignment).with(123, {})
+        expect(subject.track("my event")).to eq false
+        expect(underlying).to have_received(:track).with("my event")
       end
     end
   end
@@ -55,12 +55,12 @@ RSpec.describe TestTrack::Analytics::SafeWrapper do
     let(:error) { StandardError.new("Something went wrong") }
 
     before do
-      allow(underlying).to receive(:track_assignment).and_raise error
+      allow(underlying).to receive(:track).and_raise error
       allow(Rails.logger).to receive(:error)
     end
 
     it 'logs error to Rails.logger' do
-      subject.track_assignment(123, {})
+      subject.track("my event")
 
       expect(Rails.logger).to have_received(:error).with(error)
     end
@@ -75,7 +75,7 @@ RSpec.describe TestTrack::Analytics::SafeWrapper do
       end
 
       it 'uses custom lambda' do
-        subject.track_assignment(123, {})
+        subject.track("my event")
 
         expect(handler).to have_received(:call).with(error)
       end

--- a/spec/models/test_track/analytics_event_spec.rb
+++ b/spec/models/test_track/analytics_event_spec.rb
@@ -1,50 +1,62 @@
 require 'rails_helper'
 
 RSpec.describe TestTrack::AnalyticsEvent do
-  context "with a feature gate" do
-    let(:assignment) do
-      instance_double(
-        TestTrack::Assignment,
-        visitor_id: 34,
-        split_name: "foo_enabled",
-        variant: "true",
-        context: "home_page",
-        feature_gate?: true
-      )
-    end
+  let(:assignment) do
+    instance_double(
+      TestTrack::Assignment,
+      visitor_id: 34,
+      split_name: "foo_experiment",
+      variant: "treatment",
+      context: "home_page",
+      feature_gate?: false
+    )
+  end
 
-    subject { described_class.new(assignment) }
+  subject { described_class.new(assignment) }
 
-    it "has a name of FeatureGateExperienced" do
-      expect(subject.name).to eq "FeatureGateExperienced"
-    end
-
-    it "has a well-formed properties" do
-      expect(subject.properties).to eq(
-        TTVisitorID: 34,
-        SplitName: "foo_enabled",
-        SplitVariant: "true",
-        SplitContext: "home_page"
-      )
+  describe "#assignment" do
+    it "returns the analytics_event's assignment" do
+      expect(subject.assignment).to eq assignment
     end
   end
 
-  context "with an experiment" do
-    let(:assignment) do
-      instance_double(
-        TestTrack::Assignment,
-        visitor_id: 34,
-        split_name: "foo_experiment",
-        variant: "treatment",
-        context: "home_page",
-        feature_gate?: false
-      )
+  describe "#visitor_id" do
+    it "returns the assignment's visitor_id" do
+      expect(subject.visitor_id).to eq 34
+    end
+  end
+
+  describe "#name" do
+    it "returns SplitAssigned" do
+      expect(subject.name).to eq "SplitAssigned"
     end
 
-    subject { described_class.new(assignment) }
+    context "with a feature gate" do
+      let(:assignment) do
+        instance_double(
+          TestTrack::Assignment,
+          visitor_id: 34,
+          split_name: "foo_enabled",
+          variant: "true",
+          context: "home_page",
+          feature_gate?: true
+        )
+      end
 
-    it "has a name of SplitAssigned" do
-      expect(subject.name).to eq "SplitAssigned"
+      it "returns FeatureGateExperienced" do
+        expect(subject.name).to eq "FeatureGateExperienced"
+      end
+    end
+  end
+
+  describe "#properties" do
+    it "returns a hash with relevant facts about the assignment" do
+      expect(subject.properties).to eq(
+        TTVisitorID: 34,
+        SplitName: "foo_experiment",
+        SplitVariant: "treatment",
+        SplitContext: "home_page"
+      )
     end
   end
 end

--- a/spec/models/test_track/analytics_event_spec.rb
+++ b/spec/models/test_track/analytics_event_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe TestTrack::AnalyticsEvent do
+  context "with a feature gate" do
+    let(:assignment) do
+      instance_double(
+        TestTrack::Assignment,
+        visitor_id: 34,
+        split_name: "foo_enabled",
+        variant: "true",
+        context: "home_page",
+        feature_gate?: true
+      )
+    end
+
+    subject { described_class.new(assignment) }
+
+    it "has a name of FeatureGateExperienced" do
+      expect(subject.name).to eq "FeatureGateExperienced"
+    end
+
+    it "has a well-formed properties" do
+      expect(subject.properties).to eq(
+        TTVisitorID: 34,
+        SplitName: "foo_enabled",
+        SplitVariant: "true",
+        SplitContext: "home_page"
+      )
+    end
+  end
+
+  context "with an experiment" do
+    let(:assignment) do
+      instance_double(
+        TestTrack::Assignment,
+        visitor_id: 34,
+        split_name: "foo_experiment",
+        variant: "treatment",
+        context: "home_page",
+        feature_gate?: false
+      )
+    end
+
+    subject { described_class.new(assignment) }
+
+    it "has a name of SplitAssigned" do
+      expect(subject.name).to eq "SplitAssigned"
+    end
+  end
+end

--- a/spec/models/test_track/assignment_spec.rb
+++ b/spec/models/test_track/assignment_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe TestTrack::Assignment do
     context "for a feature gate" do
       subject { described_class.new(visitor: visitor, split_name: :feature_enabled) }
 
-      it "returns false" do
-        expect(subject.unsynced?).to eq false
+      it "also returns true" do
+        expect(subject.unsynced?).to eq true
       end
     end
   end

--- a/spec/models/test_track/assignment_spec.rb
+++ b/spec/models/test_track/assignment_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe TestTrack::Assignment do
       end
     end
   end
+
+  describe "#unsynced?" do
+    it "returns true" do
+      expect(subject.unsynced?).to eq true
+    end
+
+    context "for a feature gate" do
+      subject { described_class.new(visitor: visitor, split_name: :feature_enabled) }
+
+      it "returns false" do
+        expect(subject.unsynced?).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/test_track/fake/visitor_spec.rb
+++ b/spec/models/test_track/fake/visitor_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe TestTrack::Fake::Visitor do
     describe '#assignments' do
       it 'returns an array of assignments' do
         expect(subject.assignments).to match_array [
-          TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context"),
-          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context")
+          TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context", 1),
+          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context", 1)
         ]
       end
     end


### PR DESCRIPTION
Fixes #43 

Because feature gates aren't needed for A/B test analysis and [TestTrack server will now discard the assignment event](https://github.com/Betterment/test_track/pull/69
) in order to allow visitors to dynamically reassign upon gate weighting changes, we just deterministically assign locally each time instead and skip notification of the event.

This code change is pretty far from the notification code, but leans on the fact that all notification codepaths rely on visitor.unsynced_assignments to decide whether to send assignment notifications, which in turn calls the `unsynced?` method on assignment, which was previously hard-coded to return true - basically if the rails client made an assignment, it was considered worthy of syncing to the server before. Now we will consider feature gate assignments to be synced, so they will not trigger a notification.

This should make pages and jobs that only have feature gates (and not experiment assignments) less resource intensive than ever!