### PR TITLE
Upgrade nokogiri requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,5 @@ gem 'rack', '~> 1.6' # Make sure travis can still run tests on older rubies
 gem 'sqlite3', platforms: :ruby
 gem 'activerecord-jdbcsqlite3-adapter', platforms: :jruby
 
-gem 'nokogiri', '< 1.7.0'
+gem 'nokogiri', '~> 1.8.2'
 gem 'webmock', '< 2.3.1'


### PR DESCRIPTION
Any nokogiri 1.8 series should be fine.

/domain @Betterment/test_track_core or anybody who has recent experience with dependency versions
/no-platform

Any jruby issues? I don't remember why we had a cap on nokogiri version before.