### PR TITLE
Manage multiple identities within a web session

### DIFF
--- a/app/models/concerns/test_track/identity.rb
+++ b/app/models/concerns/test_track/identity.rb
@@ -16,36 +16,36 @@ module TestTrack::Identity
         end
 
         define_method :test_track_ab do |*args|
-          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.with_visitor do |v|
+          locator = TestTrack::IdentitySessionLocator.new(self)
+          locator.with_visitor do |v|
             v.ab(*args)
           end
         end
 
         define_method :test_track_vary do |*args, &block|
-          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.with_visitor do |v|
+          locator = TestTrack::IdentitySessionLocator.new(self)
+          locator.with_visitor do |v|
             v.vary(*args, &block)
           end
         end
 
         define_method :test_track_visitor_id do
-          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.with_visitor do |v|
+          locator = TestTrack::IdentitySessionLocator.new(self)
+          locator.with_visitor do |v|
             v.id
           end
         end
 
         define_method :test_track_sign_up! do
-          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.with_session do |session|
+          locator = TestTrack::IdentitySessionLocator.new(self)
+          locator.with_session do |session|
             session.sign_up! self
           end
         end
 
         define_method :test_track_log_in! do |opts = {}|
-          discriminator = TestTrack::IdentitySessionDiscriminator.new(self)
-          discriminator.with_session do |session|
+          locator = TestTrack::IdentitySessionLocator.new(self)
+          locator.with_session do |session|
             session.log_in! self, opts
           end
         end

--- a/app/models/test_track/identity_session_locator.rb
+++ b/app/models/test_track/identity_session_locator.rb
@@ -1,4 +1,4 @@
-class TestTrack::IdentitySessionDiscriminator
+class TestTrack::IdentitySessionLocator
   attr_reader :identity
 
   def initialize(identity)
@@ -8,8 +8,8 @@ class TestTrack::IdentitySessionDiscriminator
   def with_visitor
     raise ArgumentError, "must provide block to `with_visitor`" unless block_given?
 
-    if matching_identity?
-      yield session.visitor_dsl
+    if web_context?
+      yield session.visitor_dsl_for(identity)
     else
       TestTrack::OfflineSession.with_visitor_for(identity.test_track_identifier_type, identity.test_track_identifier_value) do |v|
         yield v
@@ -28,10 +28,6 @@ class TestTrack::IdentitySessionDiscriminator
   end
 
   private
-
-  def matching_identity?
-    session.present? && session.has_matching_identity?(identity)
-  end
 
   def web_context?
     session.present?

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -16,6 +16,27 @@ class TestTrack::Session
     notify_unsynced_assignments! if sync_assignments?
   end
 
+  def visitor_dsl_for(identity)
+    if has_matching_identity?(identity)
+      visitor_dsl
+    else
+      TestTrack::VisitorDSL.new(visitors_by_identity[identity])
+    end
+  end
+
+  def visitors_by_identity
+    @visitors_by_identity ||= Hash.new do |visitors_by_identity, identity|
+      remote_visitor = TestTrack::Remote::Visitor.from_identifier(
+        identity.test_track_identifier_type,
+        identity.test_track_identifier_value
+      )
+      visitors_by_identity[identity] = TestTrack::Visitor.new(
+        id: remote_visitor.id,
+        assignments: remote_visitor.assignments
+      )
+    end
+  end
+
   def visitor_dsl
     @visitor_dsl ||= TestTrack::VisitorDSL.new(visitor)
   end

--- a/spec/models/concerns/test_track/identity_spec.rb
+++ b/spec/models/concerns/test_track/identity_spec.rb
@@ -5,19 +5,19 @@ RSpec.describe TestTrack::Identity do
 
   describe ".test_track_identifier" do
     context "#test_track_ab" do
-      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:identity_session_locator) { instance_double(TestTrack::IdentitySessionLocator) }
       let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, ab: false) }
 
       before do
-        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
-        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
+        allow(TestTrack::IdentitySessionLocator).to receive(:new).and_return(identity_session_locator)
+        allow(identity_session_locator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      it "delegates to the session discriminator" do
+      it "delegates to the session locator" do
         expect(subject.test_track_ab(:blue_button, context: :spec)).to be false
 
-        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
-        expect(identity_session_discriminator).to have_received(:with_visitor)
+        expect(TestTrack::IdentitySessionLocator).to have_received(:new).with(subject)
+        expect(identity_session_locator).to have_received(:with_visitor)
         expect(visitor_dsl).to have_received(:ab).with(:blue_button, context: :spec)
       end
     end
@@ -30,71 +30,71 @@ RSpec.describe TestTrack::Identity do
         end
       end
 
-      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:identity_session_locator) { instance_double(TestTrack::IdentitySessionLocator) }
       let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, vary: "salad please") }
 
       before do
-        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
-        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
+        allow(TestTrack::IdentitySessionLocator).to receive(:new).and_return(identity_session_locator)
+        allow(identity_session_locator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      it "delegates to the session discriminator" do
+      it "delegates to the session locator" do
         expect(vary_side_dish).to eq "salad please"
 
-        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
-        expect(identity_session_discriminator).to have_received(:with_visitor)
+        expect(TestTrack::IdentitySessionLocator).to have_received(:new).with(subject)
+        expect(identity_session_locator).to have_received(:with_visitor)
         expect(visitor_dsl).to have_received(:vary).with(:side_dish, context: :spec)
       end
     end
 
     context "#test_track_visitor_id" do
-      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:identity_session_locator) { instance_double(TestTrack::IdentitySessionLocator) }
       let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL, id: "a_fake_id") }
 
       before do
-        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
-        allow(identity_session_discriminator).to receive(:with_visitor).and_yield(visitor_dsl)
+        allow(TestTrack::IdentitySessionLocator).to receive(:new).and_return(identity_session_locator)
+        allow(identity_session_locator).to receive(:with_visitor).and_yield(visitor_dsl)
       end
 
-      it "returns the correct value from the session discriminator" do
+      it "returns the correct value from the session locator" do
         expect(subject.test_track_visitor_id).to eq 'a_fake_id'
       end
     end
 
     context "#test_track_sign_up!" do
-      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:identity_session_locator) { instance_double(TestTrack::IdentitySessionLocator) }
       let(:session) { instance_double(TestTrack::Session) }
 
       before do
-        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
-        allow(identity_session_discriminator).to receive(:with_session).and_yield(session)
+        allow(TestTrack::IdentitySessionLocator).to receive(:new).and_return(identity_session_locator)
+        allow(identity_session_locator).to receive(:with_session).and_yield(session)
         allow(session).to receive(:sign_up!)
       end
 
-      it "delegates to the session discriminator" do
+      it "delegates to the session locator" do
         subject.test_track_sign_up!
 
-        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
-        expect(identity_session_discriminator).to have_received(:with_session)
+        expect(TestTrack::IdentitySessionLocator).to have_received(:new).with(subject)
+        expect(identity_session_locator).to have_received(:with_session)
         expect(session).to have_received(:sign_up!).with(subject)
       end
     end
 
     context "#test_track_log_in!" do
-      let(:identity_session_discriminator) { instance_double(TestTrack::IdentitySessionDiscriminator) }
+      let(:identity_session_locator) { instance_double(TestTrack::IdentitySessionLocator) }
       let(:session) { instance_double(TestTrack::Session) }
 
       before do
-        allow(TestTrack::IdentitySessionDiscriminator).to receive(:new).and_return(identity_session_discriminator)
-        allow(identity_session_discriminator).to receive(:with_session).and_yield(session)
+        allow(TestTrack::IdentitySessionLocator).to receive(:new).and_return(identity_session_locator)
+        allow(identity_session_locator).to receive(:with_session).and_yield(session)
         allow(session).to receive(:log_in!)
       end
 
-      it "delegates to the session discriminator" do
+      it "delegates to the session locator" do
         subject.test_track_log_in! forget_current_visitor: true
 
-        expect(TestTrack::IdentitySessionDiscriminator).to have_received(:new).with(subject)
-        expect(identity_session_discriminator).to have_received(:with_session)
+        expect(TestTrack::IdentitySessionLocator).to have_received(:new).with(subject)
+        expect(identity_session_locator).to have_received(:with_session)
         expect(session).to have_received(:log_in!).with(subject, forget_current_visitor: true)
       end
     end

--- a/spec/models/test_track/identity_session_locator_spec.rb
+++ b/spec/models/test_track/identity_session_locator_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe TestTrack::IdentitySessionDiscriminator do
+RSpec.describe TestTrack::IdentitySessionLocator do
   let(:identity) { Clown.new(id: 1234) }
 
-  subject { TestTrack::IdentitySessionDiscriminator.new(identity) }
+  subject { described_class.new(identity) }
 
   describe "#with_visitor" do
     it "raises without a provided block" do
@@ -16,36 +16,12 @@ RSpec.describe TestTrack::IdentitySessionDiscriminator do
 
       before do
         allow(RequestStore).to receive(:[]).with(:test_track_session).and_return(test_track_session)
-        allow(test_track_session).to receive(:has_matching_identity?).and_return(has_matching_identity)
-        allow(test_track_session).to receive(:visitor_dsl).and_return(visitor_dsl)
+        allow(test_track_session).to receive(:visitor_dsl_for).and_return(visitor_dsl)
       end
 
-      context "when the session has a matching identity" do
-        let(:has_matching_identity) { true }
-
-        it "yields the session's visitor dsl" do
-          subject.with_visitor do |visitor|
-            expect(visitor).to eq visitor_dsl
-          end
-
-          expect(test_track_session).to have_received(:has_matching_identity?).with(identity)
-        end
-      end
-
-      context "when the session does not have a matching identity" do
-        let(:has_matching_identity) { false }
-        let(:visitor_dsl) { instance_double(TestTrack::VisitorDSL) }
-
-        before do
-          allow(TestTrack::OfflineSession).to receive(:with_visitor_for).and_yield(visitor_dsl)
-        end
-
-        it "creates an offline session and yields its visitor" do
-          subject.with_visitor do |visitor|
-            expect(visitor).to eq visitor_dsl
-          end
-
-          expect(TestTrack::OfflineSession).to have_received(:with_visitor_for).with("clown_id", 1234)
+      it "yields the session's visitor dsl" do
+        subject.with_visitor do |visitor|
+          expect(visitor).to eq visitor_dsl
         end
       end
     end

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -472,7 +472,6 @@ RSpec.describe TestTrack::Session do
       subject.visitors_by_identity[identity]
 
       expect(TestTrack::Remote::Visitor).to have_received(:from_identifier).with("foo_user_id", "123").exactly(:once)
-
     end
   end
 

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -422,6 +422,60 @@ RSpec.describe TestTrack::Session do
     end
   end
 
+  describe "#visitor_dsl_for" do
+    before do
+      allow(TestTrack::Remote::Visitor).to receive(:from_identifier).and_call_original
+    end
+
+    context "when the controller's authenticated resource matches the identity" do
+      before do
+        allow(controller).to receive(:current_clown).and_return(identity)
+      end
+
+      it "doesn't fetch a remote visitor" do
+        expect(subject.visitor_dsl_for(identity)).to be_a TestTrack::VisitorDSL
+
+        expect(TestTrack::Remote::Visitor).not_to have_received(:from_identifier)
+      end
+    end
+
+    context "when the controller's authenticated resource does not match the identity" do
+      let(:other_identity) { Clown.new(id: 9876) }
+
+      before do
+        allow(controller).to receive(:current_clown).and_return(other_identity)
+      end
+
+      it "fetches a remote visitor" do
+        expect(subject.visitor_dsl_for(identity)).to be_a TestTrack::VisitorDSL
+
+        expect(TestTrack::Remote::Visitor).to have_received(:from_identifier).with('clown_id', 1234)
+      end
+    end
+  end
+
+  describe "#visitors_by_identity" do
+    let(:identity) { double(test_track_identifier_type: "foo_user_id", test_track_identifier_value: "123") }
+
+    before do
+      allow(TestTrack::Remote::Visitor).to receive(:from_identifier).and_call_original
+    end
+
+    it "fetches a remote visitor on demand given an identity" do
+      expect(subject.visitors_by_identity[identity]).to be_a TestTrack::Visitor
+
+      expect(TestTrack::Remote::Visitor).to have_received(:from_identifier).with("foo_user_id", "123")
+    end
+
+    it "only fetches a remote visitor once for the same identity" do
+      subject.visitors_by_identity[identity]
+      subject.visitors_by_identity[identity]
+
+      expect(TestTrack::Remote::Visitor).to have_received(:from_identifier).with("foo_user_id", "123").exactly(:once)
+
+    end
+  end
+
   describe "#visitor_dsl" do
     let(:visitor) { instance_double(TestTrack::Visitor) }
 


### PR DESCRIPTION
/domain @samandmoore @smudge 
/cc @noveng05

I haven't tried this out in anger yet, but the tests pass and I wanted to get some feedback.

This is not a perfect factoring. Ideally we can decouple sessions from controllers more (so we can make offline sessions also fully stateful and employ RequestStore) and not special case the currently signed in identity so hard.