### PR TITLE
Bump version to 4.0.0-alpha1

### DIFF
--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "3.0.1" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0-alpha1" # rubocop:disable Style/MutableConstant
 end


### PR DESCRIPTION
Functionally improves on 3.0.1 (skips sending assignments to TT for feature gates, upgrades analytics client contract) but we're not done yet with 4.0.0 features (fully managed offline sessions)

/domain @samandmoore 
/no-platform