### PR TITLE
Fix module resolution bug for TestTrack::AnalyticsEvent

### DIFF
--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -24,7 +24,7 @@ class TestTrack::Assignment
   end
 
   def analytics_event
-    @analytics_event ||= AnalyticsEvent.new(self)
+    @analytics_event ||= TestTrack::AnalyticsEvent.new(self)
   end
 
   def visitor_id

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha3" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha4" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/assignment_spec.rb
+++ b/spec/models/test_track/assignment_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe TestTrack::Assignment do
     end
   end
 
+  describe "#analytics_event" do
+    it "returns an analytics_event" do
+      expect(subject.analytics_event).to be_a(TestTrack::AnalyticsEvent)
+    end
+  end
+
   describe "#variant" do
     let(:variant) { :the_variant }
     let(:variant_calculator) { instance_double(TestTrack::VariantCalculator, variant: variant) }


### PR DESCRIPTION
All of the alphas. This simple memoized getter never worked, and I didn't test it. Womp. Cutting alpha4 off the back of this too.

/domain @samandmoore @noveng05
/no-platform