### PR TITLE
Give offline sessions analytics-capable assignments

### DIFF
--- a/app/models/test_track/offline_session.rb
+++ b/app/models/test_track/offline_session.rb
@@ -1,4 +1,10 @@
 class TestTrack::OfflineSession
+  AnalyticsAssignment = Struct.new(:visitor_id, :split_name, :variant, :context, :unsynced) do
+    def unsynced?
+      unsynced
+    end
+  end
+
   def initialize(remote_visitor)
     @remote_visitor = remote_visitor
   end
@@ -30,8 +36,20 @@ class TestTrack::OfflineSession
   def visitor
     @visitor ||= TestTrack::Visitor.new(
       id: remote_visitor.id,
-      assignments: remote_visitor.assignments
+      assignments: analytics_assignments
     )
+  end
+
+  def analytics_assignments
+    remote_visitor.assignments.map do |remote_assignment|
+      AnalyticsAssignment.new(
+        remote_visitor.id,
+        remote_assignment.split_name,
+        remote_assignment.variant,
+        remote_assignment.context,
+        remote_assignment.unsynced
+      )
+    end
   end
 
   def manage

--- a/app/models/test_track/remote/assignment.rb
+++ b/app/models/test_track/remote/assignment.rb
@@ -1,7 +1,7 @@
 class TestTrack::Remote::Assignment
   include TestTrack::RemoteModel
 
-  attributes :visitor_id, :split_name, :variant, :unsynced
+  attributes :visitor_id, :split_name, :variant, :context, :unsynced
 
   validates :visitor_id, :split_name, :variant, :mixpanel_result, presence: true
 

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha4" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha5" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/offline_session_spec.rb
+++ b/spec/models/test_track/offline_session_spec.rb
@@ -33,8 +33,11 @@ RSpec.describe TestTrack::OfflineSession do
       expect(TestTrack::Visitor).to have_received(:new) do |args|
         expect(args[:id]).to eq("remote_visitor_id")
         args[:assignments].first.tap do |assignment|
+          expect(assignment.visitor_id).to eq("remote_visitor_id")
           expect(assignment.split_name).to eq("foo")
           expect(assignment.variant).to eq("bar")
+          expect(assignment).to respond_to(:context)
+          expect(assignment.unsynced?).to eq false
         end
       end
     end


### PR DESCRIPTION
/domain @noveng05 @samandmoore 
/no-platform

Apparently we used to use Remote::Assignments to fill the visitor assignment bag from offline sessions. Offline sessions attempt to sync assignments that failed the first time around. But now, there's not enough information in a Remote::Assignment to generate an AnalyticsEvent, so we need an adapter.

This is a temporary refactor to make everything work. Ultimately we want to normalize online and offline sessions and use the same types of things in both situations.