### PR TITLE
Clean up assignment interface

### DIFF
--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -23,10 +23,6 @@ class TestTrack::Assignment
     split_name.end_with?('_enabled')
   end
 
-  def analytics_event
-    @analytics_event ||= TestTrack::AnalyticsEvent.new(self)
-  end
-
   def visitor_id
     visitor.id
   end

--- a/app/models/test_track/notify_assignment_job.rb
+++ b/app/models/test_track/notify_assignment_job.rb
@@ -27,7 +27,7 @@ class TestTrack::NotifyAssignmentJob
 
   def track
     return "failure" unless TestTrack.enabled?
-    result = TestTrack.analytics.track(assignment.analytics_event)
+    result = TestTrack.analytics.track(TestTrack::AnalyticsEvent.new(assignment))
     result ? "success" : "failure"
   end
 end

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha5" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha6" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/assignment_spec.rb
+++ b/spec/models/test_track/assignment_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe TestTrack::Assignment do
     end
   end
 
-  describe "#analytics_event" do
-    it "returns an analytics_event" do
-      expect(subject.analytics_event).to be_a(TestTrack::AnalyticsEvent)
-    end
-  end
-
   describe "#variant" do
     let(:variant) { :the_variant }
     let(:variant_calculator) { instance_double(TestTrack::VariantCalculator, variant: variant) }

--- a/spec/models/test_track/notify_assignment_job_spec.rb
+++ b/spec/models/test_track/notify_assignment_job_spec.rb
@@ -2,15 +2,13 @@ require 'rails_helper'
 
 RSpec.describe TestTrack::NotifyAssignmentJob do
   let(:feature_gate) { false }
-  let(:analytics_event) { instance_double(TestTrack::AnalyticsEvent) }
   let(:assignment) do
     instance_double(
       TestTrack::Assignment,
       split_name: "phaser",
       variant: "stun",
       context: "the_context",
-      feature_gate?: feature_gate,
-      analytics_event: analytics_event
+      feature_gate?: feature_gate
     )
   end
   let(:params) do
@@ -52,7 +50,7 @@ RSpec.describe TestTrack::NotifyAssignmentJob do
     it "sends analytics event" do
       with_test_track_enabled { subject.perform }
 
-      expect(TestTrack.analytics).to have_received(:track).with(analytics_event)
+      expect(TestTrack.analytics).to have_received(:track).with(instance_of(TestTrack::AnalyticsEvent))
     end
 
     it "sends test_track assignment" do
@@ -78,7 +76,7 @@ RSpec.describe TestTrack::NotifyAssignmentJob do
       it "still sends analytics events" do
         with_test_track_enabled { subject.perform }
 
-        expect(TestTrack.analytics).to have_received(:track).with(analytics_event)
+        expect(TestTrack.analytics).to have_received(:track).with(instance_of(TestTrack::AnalyticsEvent))
       end
     end
 


### PR DESCRIPTION
/domain @noveng05 @samandmoore 
/no-platform

urrrrg I keep finding more breakage. This removes the Assignment#analytics_event method so we can duck type it like I should've done last version.

I think I'm close to the bottom of the rabbit hole. This is the only thing currently generating errbits in stage.