### PR TITLE
AnalyticsAssignments need to say whether they're feature gates

### DIFF
--- a/app/models/test_track/offline_session.rb
+++ b/app/models/test_track/offline_session.rb
@@ -3,6 +3,10 @@ class TestTrack::OfflineSession
     def unsynced?
       unsynced
     end
+
+    def feature_gate?
+      split_name.end_with?('_enabled')
+    end
   end
 
   def initialize(remote_visitor)

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha6" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha7" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/offline_session_spec.rb
+++ b/spec/models/test_track/offline_session_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe TestTrack::OfflineSession do
           expect(assignment.variant).to eq("bar")
           expect(assignment).to respond_to(:context)
           expect(assignment.unsynced?).to eq false
+          expect(assignment.feature_gate?).to eq false
         end
       end
     end


### PR DESCRIPTION
/domain @samandmoore @noveng05
/no-platform

It keeps getting better and hackier. Maybe this is the bottom. I wish the testing cycle were better on this jazz. Now we're deciding which analytics event name to send at last. Getting close.