### PR TITLE
Fix analytics tracking errors by providing visitor_id for remote assignments

### DIFF
--- a/app/models/test_track/analytics_event.rb
+++ b/app/models/test_track/analytics_event.rb
@@ -1,10 +1,9 @@
 module TestTrack
   class AnalyticsEvent
-    attr_reader :assignment
+    attr_reader :visitor_id, :assignment
 
-    delegate :visitor_id, to: :assignment
-
-    def initialize(assignment)
+    def initialize(visitor_id, assignment)
+      @visitor_id = visitor_id
       @assignment = assignment
     end
 

--- a/app/models/test_track/assignment.rb
+++ b/app/models/test_track/assignment.rb
@@ -23,10 +23,6 @@ class TestTrack::Assignment
     split_name.end_with?('_enabled')
   end
 
-  def visitor_id
-    visitor.id
-  end
-
   private
 
   def _variant

--- a/app/models/test_track/fake/visitor.rb
+++ b/app/models/test_track/fake/visitor.rb
@@ -1,7 +1,7 @@
 class TestTrack::Fake::Visitor
   attr_reader :id
 
-  Assignment = Struct.new(:split_name, :variant, :unsynced, :context, :visitor_id)
+  Assignment = Struct.new(:split_name, :variant, :unsynced, :context)
 
   def self.instance
     @instance ||= new(TestTrack::FakeServer.seed)
@@ -28,7 +28,7 @@ class TestTrack::Fake::Visitor
   def _assignments
     split_registry.keys.map do |split_name|
       variant = TestTrack::VariantCalculator.new(visitor: self, split_name: split_name).variant
-      Assignment.new(split_name, variant, false, "the_context", id)
+      Assignment.new(split_name, variant, false, "the_context")
     end
   end
 end

--- a/app/models/test_track/notify_assignment_job.rb
+++ b/app/models/test_track/notify_assignment_job.rb
@@ -27,7 +27,7 @@ class TestTrack::NotifyAssignmentJob
 
   def track
     return "failure" unless TestTrack.enabled?
-    result = TestTrack.analytics.track(TestTrack::AnalyticsEvent.new(assignment))
+    result = TestTrack.analytics.track(TestTrack::AnalyticsEvent.new(visitor_id, assignment))
     result ? "success" : "failure"
   end
 end

--- a/app/models/test_track/offline_session.rb
+++ b/app/models/test_track/offline_session.rb
@@ -1,14 +1,4 @@
 class TestTrack::OfflineSession
-  AnalyticsAssignment = Struct.new(:visitor_id, :split_name, :variant, :context, :unsynced) do
-    def unsynced?
-      unsynced
-    end
-
-    def feature_gate?
-      split_name.end_with?('_enabled')
-    end
-  end
-
   def initialize(remote_visitor)
     @remote_visitor = remote_visitor
   end
@@ -40,20 +30,8 @@ class TestTrack::OfflineSession
   def visitor
     @visitor ||= TestTrack::Visitor.new(
       id: remote_visitor.id,
-      assignments: analytics_assignments
+      assignments: remote_visitor.assignments
     )
-  end
-
-  def analytics_assignments
-    remote_visitor.assignments.map do |remote_assignment|
-      AnalyticsAssignment.new(
-        remote_visitor.id,
-        remote_assignment.split_name,
-        remote_assignment.variant,
-        remote_assignment.context,
-        remote_assignment.unsynced
-      )
-    end
   end
 
   def manage

--- a/app/models/test_track/remote/assignment.rb
+++ b/app/models/test_track/remote/assignment.rb
@@ -9,6 +9,10 @@ class TestTrack::Remote::Assignment
     unsynced || variant_changed?
   end
 
+  def feature_gate?
+    split_name.end_with?('_enabled')
+  end
+
   def self.fake_instance_attributes(id)
     {
       split_name: "split_#{id}",

--- a/app/models/test_track/remote/assignment.rb
+++ b/app/models/test_track/remote/assignment.rb
@@ -1,9 +1,9 @@
 class TestTrack::Remote::Assignment
   include TestTrack::RemoteModel
 
-  attributes :visitor_id, :split_name, :variant, :context, :unsynced
+  attributes :split_name, :variant, :context, :unsynced
 
-  validates :visitor_id, :split_name, :variant, :mixpanel_result, presence: true
+  validates :split_name, :variant, :mixpanel_result, presence: true
 
   def unsynced?
     unsynced || variant_changed?

--- a/spec/models/test_track/analytics_event_spec.rb
+++ b/spec/models/test_track/analytics_event_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe TestTrack::AnalyticsEvent do
+  let(:visitor_id) { 34 }
   let(:assignment) do
     instance_double(
       TestTrack::Assignment,
-      visitor_id: 34,
       split_name: "foo_experiment",
       variant: "treatment",
       context: "home_page",
@@ -12,7 +12,7 @@ RSpec.describe TestTrack::AnalyticsEvent do
     )
   end
 
-  subject { described_class.new(assignment) }
+  subject { described_class.new(visitor_id, assignment) }
 
   describe "#assignment" do
     it "returns the analytics_event's assignment" do
@@ -21,7 +21,7 @@ RSpec.describe TestTrack::AnalyticsEvent do
   end
 
   describe "#visitor_id" do
-    it "returns the assignment's visitor_id" do
+    it "returns the supplied visitor_id" do
       expect(subject.visitor_id).to eq 34
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe TestTrack::AnalyticsEvent do
       let(:assignment) do
         instance_double(
           TestTrack::Assignment,
-          visitor_id: 34,
           split_name: "foo_enabled",
           variant: "true",
           context: "home_page",

--- a/spec/models/test_track/assignment_spec.rb
+++ b/spec/models/test_track/assignment_spec.rb
@@ -62,4 +62,22 @@ RSpec.describe TestTrack::Assignment do
       end
     end
   end
+
+  describe "#feature_gate?" do
+    context "when the split name ends with '_enabled'" do
+      subject { described_class.new(visitor: visitor, split_name: :feature_enabled) }
+
+      it "returns true" do
+        expect(subject.feature_gate?).to eq true
+      end
+    end
+
+    context "when the split name ends with something else" do
+      subject { described_class.new(visitor: visitor, split_name: :feature_experiment) }
+
+      it "returns false" do
+        expect(subject.feature_gate?).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/test_track/fake/visitor_spec.rb
+++ b/spec/models/test_track/fake/visitor_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe TestTrack::Fake::Visitor do
     describe '#assignments' do
       it 'returns an array of assignments' do
         expect(subject.assignments).to match_array [
-          TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context", 1),
-          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context", 1)
+          TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context"),
+          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context")
         ]
       end
     end

--- a/spec/models/test_track/offline_session_spec.rb
+++ b/spec/models/test_track/offline_session_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe TestTrack::OfflineSession do
       expect(TestTrack::Visitor).to have_received(:new) do |args|
         expect(args[:id]).to eq("remote_visitor_id")
         args[:assignments].first.tap do |assignment|
-          expect(assignment.visitor_id).to eq("remote_visitor_id")
           expect(assignment.split_name).to eq("foo")
           expect(assignment.variant).to eq("bar")
           expect(assignment).to respond_to(:context)


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform
/cc @wcirillo @jmileham 

We've been seeing a lot of error logging in our analytics code related to assignments with a missing visitor id. I think its caused by a difference between the remote and local assignment classes.

Both have a `visitor_id` attribute, but for remote assignments, [no value is returned](https://github.com/Betterment/test_track/blob/master/app/views/api/v1/visitors/_show.json.jbuilder#L2) in the response from the TT server.

So when you stuff a remote assignment into an `AnalyticsEvent`, you'll have a nil `visitor_id`, which will lead to errors.

I think the root cause is that `TestTrack::Remote::Assignment` has had an attribute for `visitor_id` for a long time, but it looks like it was never populated. So when [refactoring the analytics code](https://github.com/Betterment/test_track_rails_client/pull/44), we leaned on the existence of that attribute.

The fix is to pass in a `visitor_id` to the `AnalyticsEvent` and no longer delegate to the `Assignment`. I've also removed the visitor_id attributes from all the relevant classes to avoid confusion in the future.