### PR TITLE
Add `TestTrack.app_ab` for application-wide feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ end
 
 The `TestTrack.app_ab` method uses an "app" identifier type to be able to globally access "Feature Gate" splits. This is useful when a visitor context is not handy, and when you don't care about visitor specific assignments.
 
+In order to use this feature, you need to set `TestTrack.app_name`, preferably in an app initializer.
+
+```ruby
+# config/initializers/test_track.rb
+TestTrack.app_name = "MyApp"
+```
+
 ```ruby
 class BackgroundWorkJob
   def perform

--- a/README.md
+++ b/README.md
@@ -267,6 +267,21 @@ class User
   test_track_identifier :myapp_user_id, :id # `id` is a column on User model which is what we're using as the identifier value in this example.
 end
 ```
+### Varying app behavior globally
+
+The `TestTrack.app_ab` method uses an "app" identifier type to be able to globally access "Feature Gate" splits. This is useful when a visitor context is not handy, and when you don't care about visitor specific assignments.
+
+```ruby
+class BackgroundWorkJob
+  def perform
+    if TestTrack.app_ab(:fancy_new_api_enabled, context: 'BackgroundWorkJob')
+      FancyNewApi.do_thing
+    else
+      CruftyOldApi.do_thing
+    end
+  end
+end
+``` 
 
 ## Tracking visitor logins
 

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -1,13 +1,13 @@
 class TestTrack::ApplicationIdentity
-	include Singleton
-	include TestTrack::Identity
+  include Singleton
+  include TestTrack::Identity
 
-	test_track_identifier :app_id, :app_name
+  test_track_identifier :app_id, :app_name
 
-	private
+  private
 
-	def app_name
-		raise 'must configure TestTrack.app_name on application initialization' unless TestTrack.app_name.present?
-		TestTrack.app_name
-	end
+  def app_name
+    raise 'must configure TestTrack.app_name on application initialization' if TestTrack.app_name.blank?
+    TestTrack.app_name
+  end
 end

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -1,8 +1,7 @@
 class TestTrack::ApplicationIdentity
   include Singleton
-  include TestTrack::Identity
 
-  test_track_identifier :app_id, :app_name
+  delegate :test_track_ab, to: :private_identity
 
   private
 
@@ -10,4 +9,24 @@ class TestTrack::ApplicationIdentity
     raise 'must configure TestTrack.app_name on application initialization' if TestTrack.app_name.blank?
     TestTrack.app_name
   end
+
+  def private_identity
+    PrivateIdentity.new(app_name)
+  end
+
+  class PrivateIdentity
+    include TestTrack::Identity
+
+    test_track_identifier :app_id, :app_name
+
+    def initialize(app_name)
+      @app_name = app_name
+    end
+
+    private
+
+    attr_reader :app_name
+  end
+
+  private_constant :PrivateIdentity
 end

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -1,0 +1,13 @@
+class TestTrack::ApplicationIdentity
+	include Singleton
+	include TestTrack::Identity
+
+	test_track_identifier :app_id, :app_name
+
+	private
+
+	def app_name
+		raise 'must configure TestTrack.app_name on application initialization' unless TestTrack.app_name.present?
+		TestTrack.app_name
+	end
+end

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -1,7 +1,7 @@
 class TestTrack::ApplicationIdentity
   include Singleton
 
-  delegate :test_track_ab, to: :private_identity
+  delegate :test_track_ab, to: :identity
 
   private
 
@@ -10,11 +10,11 @@ class TestTrack::ApplicationIdentity
     TestTrack.app_name
   end
 
-  def private_identity
-    PrivateIdentity.new(app_name)
+  def identity
+    Identity.new(app_name)
   end
 
-  class PrivateIdentity
+  class Identity
     include TestTrack::Identity
 
     test_track_identifier :app_id, :app_name
@@ -28,5 +28,5 @@ class TestTrack::ApplicationIdentity
     attr_reader :app_name
   end
 
-  private_constant :PrivateIdentity
+  private_constant :Identity
 end

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -16,7 +16,7 @@ module TestTrack
 
   SERVER_ERRORS = [Faraday::ConnectionFailed, Faraday::TimeoutError, Her::Errors::RemoteServerError].freeze
 
-  mattr_accessor :enabled_override
+  mattr_accessor :enabled_override, :app_name
 
   class << self
     def analytics
@@ -56,5 +56,13 @@ module TestTrack
 
   def enabled?
     enabled_override.nil? ? !Rails.env.test? : enabled_override
+  end
+
+  def feature_enabled?(split_name, context:)
+    app.test_track_ab(split_name, context: context)
+  end
+
+  def app
+    TestTrack::ApplicationIdentity.instance
   end
 end

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -62,7 +62,7 @@ module TestTrack
     enabled_override.nil? ? !Rails.env.test? : enabled_override
   end
 
-  def feature_enabled?(split_name, context:)
+  def app_ab(split_name, context:)
     app.test_track_ab(split_name, context: context)
   end
 end

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -36,6 +36,10 @@ module TestTrack
     def mixpanel
       TestTrack::Analytics::MixpanelClient.new
     end
+
+    def app
+      TestTrack::ApplicationIdentity.instance
+    end
   end
 
   def update_config
@@ -60,9 +64,5 @@ module TestTrack
 
   def feature_enabled?(split_name, context:)
     app.test_track_ab(split_name, context: context)
-  end
-
-  def app
-    TestTrack::ApplicationIdentity.instance
   end
 end

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -105,9 +105,6 @@ RSpec.describe TestTrack do
       end
 
       it "raises an error" do
-        Rails.logger.info "It should raise an error"
-        Rails.logger.info TestTrack.app_name
-        Rails.logger.info "Just logged app_name"
         expect { TestTrack.app_ab(:dummy_feature, context: 'test_context') }
           .to raise_error("must configure TestTrack.app_name on application initialization")
       end

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe TestTrack do
     end
 
     context "when app_name is not specified" do
-      before do 
-        TestTrack.app_name = nil 
+      before do
+        TestTrack.app_name = nil
       end
 
       it "raises an error" do

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'test_track_rails_client/rspec_helpers'
 
 RSpec.describe TestTrack do
   describe ".update_config" do
@@ -66,7 +67,7 @@ RSpec.describe TestTrack do
     end
   end
 
-  describe ".feature_enabled?" do
+  describe ".app_ab" do
     around do |example|
       original_app_name = TestTrack.instance_variable_get("@app_name")
       example.run
@@ -81,7 +82,7 @@ RSpec.describe TestTrack do
           stub_test_track_assignments(dummy_feature: 'true')
         end
         it "returns true" do
-          expect(TestTrack.feature_enabled?(:dummy_feature, context: 'test_context')).to eq true
+          expect(TestTrack.app_ab(:dummy_feature, context: 'test_context')).to eq true
         end
       end
 
@@ -91,7 +92,7 @@ RSpec.describe TestTrack do
         end
 
         it "returns false" do
-          expect(TestTrack.feature_enabled?(:dummy_feature, context: 'test_context')).to eq false
+          expect(TestTrack.app_ab(:dummy_feature, context: 'test_context')).to eq false
         end
       end
       it "returns the result of the application user's assignment to a feature" do
@@ -99,10 +100,15 @@ RSpec.describe TestTrack do
     end
 
     context "when app_name is not specified" do
-      before { TestTrack.app_name = nil }
+      before do 
+        TestTrack.app_name = nil 
+      end
 
       it "raises an error" do
-        expect { TestTrack.feature_enabled?(:dummy_feature, context: 'test_context') }
+        Rails.logger.info "It should raise an error"
+        Rails.logger.info TestTrack.app_name
+        Rails.logger.info "Just logged app_name"
+        expect { TestTrack.app_ab(:dummy_feature, context: 'test_context') }
           .to raise_error("must configure TestTrack.app_name on application initialization")
       end
     end

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -65,4 +65,46 @@ RSpec.describe TestTrack do
       end
     end
   end
+
+  describe ".feature_enabled?" do
+    around do |example|
+      original_app_name = TestTrack.instance_variable_get("@app_name")
+      example.run
+      TestTrack.app_name = original_app_name
+    end
+
+    context "when app_name is specified" do
+      before { TestTrack.app_name = 'test_track_spec' }
+
+      context "when the ApplicationIdentity is assigned to the feature" do
+        before do
+          stub_test_track_assignments(dummy_feature: 'true')
+        end
+        it "returns true" do
+          expect(TestTrack.feature_enabled?(:dummy_feature, context: 'test_context')).to eq true
+        end
+      end
+
+      context "when the ApplicationIdentity is not assigned to the feature" do
+        before do
+          stub_test_track_assignments(dummy_feature: 'false')
+        end
+
+        it "returns false" do
+          expect(TestTrack.feature_enabled?(:dummy_feature, context: 'test_context')).to eq false
+        end
+      end
+      it "returns the result of the application user's assignment to a feature" do
+      end
+    end
+
+    context "when app_name is not specified" do
+      before { TestTrack.app_name = nil }
+
+      it "raises an error" do
+        expect { TestTrack.feature_enabled?(:dummy_feature, context: 'test_context') }
+          .to raise_error("must configure TestTrack.app_name on application initialization")
+      end
+    end
+  end
 end


### PR DESCRIPTION
/domain @Betterment/test_track_core
/no-platform

This adds the concept of an ApplicationIdentity, and allows apps to configure an app_name. This enables consumers to easily access app-wide feature flags, that are useful in cases that aren't necessarily tied to an end user (e.g., a background job, or toggling between different versions of an external API that your app is consuming). This allows you to decouple deployment from release without the added granularity of a gradual rollout in cases where you don't need it.

This sets up a singleton ApplicationIdentity, which is consumed through a module_method on TestTrack using `TestTrack.app_ab`. It also exposes a TestTrack attribute called `app_name` that can be configured on application initialization (and is only needed if you actually use the ApplicationIdentity).

One caveat here is that the test track server needs to have an identifier called 'app_id'. I will look into following this up with a change to the TestTrack server to provide that by default