### PR TITLE
remove requirement of `context` to test track ab and vary dsl

### DIFF
--- a/app/models/test_track/remote/assignment_event.rb
+++ b/app/models/test_track/remote/assignment_event.rb
@@ -3,7 +3,7 @@ class TestTrack::Remote::AssignmentEvent
 
   collection_path '/api/v1/assignment_event'
 
-  attributes :visitor_id, :split_name, :unsynced
+  attributes :visitor_id, :split_name, :unsynced, :context
 
   validates :visitor_id, :split_name, :mixpanel_result, presence: true
 

--- a/app/models/test_track/remote/assignment_event.rb
+++ b/app/models/test_track/remote/assignment_event.rb
@@ -3,11 +3,9 @@ class TestTrack::Remote::AssignmentEvent
 
   collection_path '/api/v1/assignment_event'
 
-  attributes :visitor_id, :split_name, :unsynced, :context
+  attributes :visitor_id, :split_name, :mixpanel_result, :context
 
   validates :visitor_id, :split_name, :mixpanel_result, presence: true
-
-  alias unsynced? unsynced
 
   def fake_save_response_attributes
     nil # :no_content is the expected response type

--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -6,7 +6,7 @@ class TestTrack::VaryDSL
 
   def initialize(opts = {})
     @assignment = require_option!(opts, :assignment)
-    @context = require_option!(opts, :context)
+    @context = opts.delete(:context)
     @split_registry = require_option!(opts, :split_registry, allow_nil: true)
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 

--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -1,6 +1,4 @@
 class TestTrack::Visitor
-  include TestTrack::RequiredOptions
-
   attr_reader :id
 
   def initialize(opts = {})
@@ -18,7 +16,7 @@ class TestTrack::Visitor
   def vary(split_name, opts = {})
     opts = opts.dup
     split_name = split_name.to_s
-    context = require_option!(opts, :context)
+    context = opts.delete(:context)
     raise "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 
     raise ArgumentError, "must provide block to `vary` for #{split_name}" unless block_given?
@@ -31,7 +29,7 @@ class TestTrack::Visitor
     opts = opts.dup
     split_name = split_name.to_s
     true_variant = opts.delete(:true_variant)
-    context = require_option!(opts, :context)
+    context = opts.delete(:context)
     raise "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 
     ab_configuration = TestTrack::ABConfiguration.new split_name: split_name, true_variant: true_variant, split_registry: split_registry

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -207,10 +207,6 @@ RSpec.describe TestTrack::Visitor do
         expect { new_visitor.vary(:blue_button, context: :spec) }.to raise_error("must provide block to `vary` for blue_button")
       end
 
-      it "requires a context" do
-        expect { new_visitor.vary(:blue_button) }.to raise_error("Must provide context")
-      end
-
       it "requires less than two defaults" do
         expect {
           new_visitor.vary(:blue_button, context: :spec) do |v|
@@ -238,10 +234,6 @@ RSpec.describe TestTrack::Visitor do
   end
 
   describe "#ab" do
-    it "requires a context" do
-      expect { new_visitor.ab("blue_button") }.to raise_error("Must provide context")
-    end
-
     it "leverages vary to configure the split" do
       allow(new_visitor).to receive(:vary).and_call_original
       new_visitor.ab "quagmire", true_variant: "manageable", context: :spec


### PR DESCRIPTION
/domain @Betterment/test_track_core
/no-platform

Make the "context" argument optional when creating/fetching assignments using Visitor#vary and Visitor#ab. In practice, we don't always use context, and it makes using TestTrack in certain contexts difficult (we often have to make some meaningless context up just to satisfy the required parameter).

Another approach would be to make this configurable per TestTrack::Identity -- the identity could set up whether or not its consumers require a context, and provide a default context if it isn't passed in. This only feels necessary if there are consumers that still want context to be required, and do not want there to ever be a nil context associated to an assignment

(reopening this https://github.com/Betterment/test_track_rails_client/pull/59 after i reset the master branch of my fork)