### PR TITLE
catch server errors, rethrow as UnrecoverableConnectivityError

### DIFF
--- a/app/models/test_track/lazy_visitor_by_identity.rb
+++ b/app/models/test_track/lazy_visitor_by_identity.rb
@@ -34,5 +34,7 @@ class TestTrack::LazyVisitorByIdentity
       id: remote_visitor.id,
       assignments: remote_visitor.assignments
     )
+  rescue *TestTrack::SERVER_ERRORS => e
+    raise TestTrackRailsClient::UnrecoverableConnectivityError, e
   end
 end

--- a/app/models/test_track/lazy_visitor_by_identity.rb
+++ b/app/models/test_track/lazy_visitor_by_identity.rb
@@ -35,6 +35,6 @@ class TestTrack::LazyVisitorByIdentity
       assignments: remote_visitor.assignments
     )
   rescue *TestTrack::SERVER_ERRORS => e
-    raise TestTrackRailsClient::UnrecoverableConnectivityError, e
+    raise TestTrack::UnrecoverableConnectivityError, e
   end
 end

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -10,6 +10,7 @@ require 'mixpanel-ruby'
 require 'resolv'
 require 'faraday_middleware'
 require 'request_store'
+require 'test_track_rails_client/unrecoverable_connectivity_error'
 
 module TestTrack
   module_function

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -10,7 +10,7 @@ require 'mixpanel-ruby'
 require 'resolv'
 require 'faraday_middleware'
 require 'request_store'
-require 'test_track_rails_client/unrecoverable_connectivity_error'
+require 'test_track/unrecoverable_connectivity_error'
 
 module TestTrack
   module_function

--- a/lib/test_track/unrecoverable_connectivity_error.rb
+++ b/lib/test_track/unrecoverable_connectivity_error.rb
@@ -1,0 +1,4 @@
+module TestTrack
+  class UnrecoverableConnectivityError < RuntimeError
+  end
+end

--- a/lib/test_track_rails_client/unrecoverable_connectivity_error.rb
+++ b/lib/test_track_rails_client/unrecoverable_connectivity_error.rb
@@ -1,0 +1,2 @@
+class TestTrackRailsClient::UnrecoverableConnectivityError < RuntimeError
+end

--- a/lib/test_track_rails_client/unrecoverable_connectivity_error.rb
+++ b/lib/test_track_rails_client/unrecoverable_connectivity_error.rb
@@ -1,2 +1,0 @@
-class TestTrackRailsClient::UnrecoverableConnectivityError < RuntimeError
-end

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha9" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha11" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/lazy_visitor_by_identity_spec.rb
+++ b/spec/models/test_track/lazy_visitor_by_identity_spec.rb
@@ -38,4 +38,17 @@ RSpec.describe TestTrack::LazyVisitorByIdentity do
       expect(subject.respond_to?(:fooblitz)).to eq false
     end
   end
+
+  context 'when cannot connect to test track server' do
+    let(:identity) { double(test_track_identifier_type: "clown_id", test_track_identifier_value: "123", assignments: []) }
+    subject { described_class.new(identity) }
+
+    before do
+      allow(TestTrack::Remote::Visitor).to receive(:from_identifier).and_raise(Faraday::TimeoutError)
+    end
+
+    it 'reraises as a TestTrackRailsClient::UnrecoverableConnectivityError' do
+      expect { subject.assignments }.to raise_error(TestTrackRailsClient::UnrecoverableConnectivityError)
+    end
+  end
 end

--- a/spec/models/test_track/lazy_visitor_by_identity_spec.rb
+++ b/spec/models/test_track/lazy_visitor_by_identity_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe TestTrack::LazyVisitorByIdentity do
       allow(TestTrack::Remote::Visitor).to receive(:from_identifier).and_raise(Faraday::TimeoutError)
     end
 
-    it 'reraises as a TestTrackRailsClient::UnrecoverableConnectivityError' do
-      expect { subject.assignments }.to raise_error(TestTrackRailsClient::UnrecoverableConnectivityError)
+    it 'reraises as a TestTrack::UnrecoverableConnectivityError' do
+      expect { subject.assignments }.to raise_error(TestTrack::UnrecoverableConnectivityError)
     end
   end
 end


### PR DESCRIPTION
/domain @jmileham @aburgel 
/no-platform

Rescue test track connectivity errors and reraise as a special error class. This will make it easier to configure our error alerting configuration (Sentry) to exclude alerting on errors fetching test track visitors.

Are there other common code paths where we should also implement this pattern?