### PR TITLE
Fix misnamed describe block

### DIFF
--- a/spec/models/concerns/test_track/remote_model_spec.rb
+++ b/spec/models/concerns/test_track/remote_model_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TestTrack::Identity do
+RSpec.describe TestTrack::RemoteModel do
   context 'handling server timeouts' do
     describe 'for get requests' do
       before do


### PR DESCRIPTION
/domain @samandmoore @jmileham 

Some bad copy-pasting here. Rename the describe block in the remote_model_spec to line up with what we are actually testing