### PR TITLE
Allow session cookie handling to work with localhost

### DIFF
--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -95,10 +95,8 @@ class TestTrack::Session
   end
 
   def _cookie_domain
-    if bare_ip_address?
+    if bare_ip_address? || fully_qualified_cookie_domain_enabled?
       request.host
-    elsif fully_qualified_cookie_domain_enabled?
-      fully_qualified_domain
     else
       wildcard_domain
     end
@@ -108,16 +106,12 @@ class TestTrack::Session
     request.host.match(Resolv::AddressRegex)
   end
 
-  def fully_qualified_domain
-    public_suffix_host.name
-  end
-
   def wildcard_domain
-    "." + public_suffix_host.domain
+    "." + (public_suffix_domain || request.host)
   end
 
-  def public_suffix_host
-    @public_suffix_host ||= PublicSuffix.parse(request.host, default_rule: nil)
+  def public_suffix_domain
+    @public_suffix_domain ||= PublicSuffix.domain(request.host, default_rule: nil)
   end
 
   def manage_cookies!

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha13" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha14" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -235,16 +235,10 @@ RSpec.describe TestTrack::Session do
         end
       end
 
-      it "checks for a valid domain" do
-        allow(request).to receive(:host).and_return("a.bad.actor;did-this<luzer>")
-        expect { subject.manage {} }.to raise_error PublicSuffix::DomainInvalid
-      end
-
-      it "checks for a valid domain when fully qualified cookie domains are enabled" do
-        with_env TEST_TRACK_FULLY_QUALIFIED_COOKIE_DOMAIN_ENABLED: 1 do
-          allow(request).to receive(:host).and_return("a.bad.actor;did-this<luzer>")
-          expect { subject.manage {} }.to raise_error PublicSuffix::DomainInvalid
-        end
+      it "works with localhost" do
+        allow(request).to receive(:host).and_return("localhost")
+        subject.manage {}
+        expect(cookies['tt_visitor_id'][:domain]).to eq ".localhost"
       end
 
       it "doesn't munge an IPv4 hostname" do


### PR DESCRIPTION
/domain @jmileham @samandmoore @smudge @effron 
/no-platform

PublicSuffix currently blows up with a `PublicSuffix::DomainInvalid` exception if you attempt to parse `localhost`. This makes it impossible to run an app with this gem via `rails s` (since that starts a server on `localhost:3000`). This modifies session cookie handling to fallback to `request.host` if PublicSuffix is not able to parse the host.

It seems like we are intentionally relying on PublicSuffix to blow up to protect against invalid host names. I'm not sure we need this gem to provide that sort of security feature, so I'm removing it (since it gets in the way of this fix). But please push back if I'm missing something.