### PR TITLE
Auto prefix split names in vary and ab

### DIFF
--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -17,6 +17,7 @@ class TestTrack::Visitor
 
   def vary(split_name, opts = {})
     opts = opts.dup
+    split_name = maybe_prefix(split_name)
     split_name = split_name.to_s
     context = require_option!(opts, :context)
     raise "unknown opts: #{opts.keys.to_sentence}" if opts.present?
@@ -29,7 +30,7 @@ class TestTrack::Visitor
 
   def ab(split_name, opts = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     opts = opts.dup
-    split_name = split_name.to_s
+    split_name = maybe_prefix(split_name)
     true_variant = opts.delete(:true_variant)
     context = require_option!(opts, :context)
     raise "unknown opts: #{opts.keys.to_sentence}" if opts.present?
@@ -147,5 +148,12 @@ class TestTrack::Visitor
 
   def generate_assignment_for(split_name)
     assignment_registry[split_name] = TestTrack::Assignment.new(visitor: self, split_name: split_name)
+  end
+
+  def maybe_prefix(split_name)
+    app_name = URI.parse(TestTrack.private_url).user
+    split_name = split_name.to_s
+    prefixed = "#{app_name}.#{split_name}"
+    split_registry.key?(prefixed) ? prefixed : split_name
   end
 end

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha17" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha18" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/visitor_spec.rb
+++ b/spec/models/test_track/visitor_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe TestTrack::Visitor do
     {
       id: existing_visitor_id,
       assignments: [
-        { split_name: 'blue_button', variant: 'true', unsynced: true, context: 'original_context' },
+        { split_name: 'dummy.blue_button', variant: 'true', unsynced: true, context: 'original_context' },
         { split_name: 'time', variant: 'waits_for_no_man', unsynced: false, context: 'original_context' }
       ]
     }
   end
   let(:split_registry) do
     {
-      'blue_button' => {
+      'dummy.blue_button' => {
         'false' => 50,
         'true' => 50
       },
@@ -59,7 +59,7 @@ RSpec.describe TestTrack::Visitor do
 
     it "returns the server-provided unsynced assignments for an existing visitor" do
       expect(existing_visitor.unsynced_assignments.count).to eq 1
-      expect(existing_visitor.unsynced_assignments.first.split_name).to eq "blue_button"
+      expect(existing_visitor.unsynced_assignments.first.split_name).to eq "dummy.blue_button"
     end
 
     it "doesn't get assignments from the server for a newly-generated visitor" do
@@ -94,7 +94,7 @@ RSpec.describe TestTrack::Visitor do
     end
 
     it "returns the server-provided assignments for an existing visitor" do
-      expect(existing_visitor.assignment_registry['blue_button'].variant).to eq 'true'
+      expect(existing_visitor.assignment_registry['dummy.blue_button'].variant).to eq 'true'
       expect(existing_visitor.assignment_registry['time'].variant).to eq 'waits_for_no_man'
     end
 
@@ -109,7 +109,7 @@ RSpec.describe TestTrack::Visitor do
 
   describe "#assignment_json" do
     it 'returns a json formatted hash of assignments' do
-      expect(existing_visitor.assignment_json).to eq("blue_button" => "true", "time" => "waits_for_no_man")
+      expect(existing_visitor.assignment_json).to eq("dummy.blue_button" => "true", "time" => "waits_for_no_man")
     end
   end
 
@@ -204,16 +204,16 @@ RSpec.describe TestTrack::Visitor do
 
     context "structure" do
       it "must be given a block" do
-        expect { new_visitor.vary(:blue_button, context: :spec) }.to raise_error("must provide block to `vary` for blue_button")
+        expect { new_visitor.vary("blue_button", context: :spec) }.to raise_error("must provide block to `vary` for dummy.blue_button")
       end
 
       it "requires a context" do
-        expect { new_visitor.vary(:blue_button) }.to raise_error("Must provide context")
+        expect { new_visitor.vary("blue_button") }.to raise_error("Must provide context")
       end
 
       it "requires less than two defaults" do
         expect {
-          new_visitor.vary(:blue_button, context: :spec) do |v|
+          new_visitor.vary("blue_button", context: :spec) do |v|
             v.when :true, &blue_block
             v.default :false, &red_block
             v.default :false, &red_block
@@ -223,13 +223,13 @@ RSpec.describe TestTrack::Visitor do
 
       it "requires more than zero defaults" do
         expect {
-          new_visitor.vary(:blue_button, context: :spec) { |v| v.when(:true, &blue_block) }
+          new_visitor.vary("dummy.blue_button", context: :spec) { |v| v.when(:true, &blue_block) }
         }.to raise_error("must provide exactly one `default`")
       end
 
       it "requires at least one when" do
         expect {
-          new_visitor.vary(:blue_button, context: :spec) do |v|
+          new_visitor.vary("dummy.blue_button", context: :spec) do |v|
             v.default :true, &red_block
           end
         }.to raise_error("must provide at least one `when`")
@@ -268,7 +268,7 @@ RSpec.describe TestTrack::Visitor do
 
       it "returns false when variant is false" do
         allow(TestTrack::VariantCalculator).to receive(:new).and_return(double(variant: 'false'))
-        expect(new_visitor.ab("blue_button", context: :spec)).to eq false
+        expect(new_visitor.ab("dummy.blue_button", context: :spec)).to eq false
       end
 
       it "returns false in production when split variants are not true and false" do
@@ -410,12 +410,12 @@ RSpec.describe TestTrack::Visitor do
 
       it "merges server-provided unsynced assignments into local unsynced assignments" do
         expect(subject.unsynced_assignments.count).to eq 1
-        expect(subject.unsynced_assignments.first.split_name).to eq 'blue_button'
+        expect(subject.unsynced_assignments.first.split_name).to eq 'dummy.blue_button'
 
         subject.link_identity!(identity)
 
         expect(subject.unsynced_assignments.count).to eq 2
-        expect(subject.unsynced_assignments.first.split_name).to eq 'blue_button'
+        expect(subject.unsynced_assignments.first.split_name).to eq 'dummy.blue_button'
         expect(subject.unsynced_assignments.second.split_name).to eq 'bar'
       end
     end


### PR DESCRIPTION
/domain @smudge @samandmoore 
/platform @smudge @samandmoore 

This will allow you to use vary and ab calls with unprefixed split names that match your current app name, which is what will happen as soon as CLI-created splits are in play.