### PR TITLE
Only try to open files that exist

### DIFF
--- a/app/models/test_track/fake/split_registry.rb
+++ b/app/models/test_track/fake/split_registry.rb
@@ -33,7 +33,8 @@ class TestTrack::Fake::SplitRegistry
   end
 
   def _schema_registry
-    file = YAML.load_file(schema_yml_path)
+    file = File.exist?(schema_yml_path) &&
+      YAML.load_file(schema_yml_path)
     file && file['splits'].each_with_object(ActiveSupport::HashWithIndifferentAccess.new) do |split, h|
       h[split['name']] = split['weights']
     end
@@ -52,13 +53,14 @@ class TestTrack::Fake::SplitRegistry
   end
 
   def _legacy_test_track_schema_yml
-    YAML.load_file(legacy_test_track_schema_yml_path).with_indifferent_access
+    File.exist?(legacy_test_track_schema_yml_path) &&
+      YAML.load_file(legacy_test_track_schema_yml_path).with_indifferent_access
   rescue
     nil
   end
 
   def legacy_test_track_schema_yml_path
-    ENV["TEST_TRACK_SCHEMA_FILE_PATH"] || Rails.root.join('db', 'test_track_schema.yml')
+    ENV["TEST_TRACK_SCHEMA_FILE_PATH"] || Rails.root.join('db', 'test_track_schema.yml').to_s
   end
 
   def splits_with_deterministic_weights

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha22" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha23" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/fake/split_registry_spec.rb
+++ b/spec/models/test_track/fake/split_registry_spec.rb
@@ -34,8 +34,10 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
 
   context "when only legacy schema exists" do
     before do
-      allow(YAML).to receive(:load_file).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_return(nil)
-      allow(YAML).to receive(:load_file).with(Rails.root.join('db', 'test_track_schema.yml')).and_call_original
+      allow(File).to receive(:exist?).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_return(false)
+      allow(YAML).to receive(:load_file).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_raise("foo")
+      allow(File).to receive(:exist?).with(Rails.root.join('db', 'test_track_schema.yml').to_s).and_return(true)
+      allow(YAML).to receive(:load_file).with(Rails.root.join('db', 'test_track_schema.yml').to_s).and_call_original
     end
 
     describe '#to_h' do
@@ -68,8 +70,10 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
 
   context "when both schema.ymls don't exist" do
     before do
-      allow(YAML).to receive(:load_file).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_return(nil)
-      allow(YAML).to receive(:load_file).with(Rails.root.join('db', 'test_track_schema.yml')).and_return(nil)
+      allow(File).to receive(:exist?).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_return(false)
+      allow(YAML).to receive(:load_file).with(Rails.root.join('testtrack', 'schema.yml').to_s).and_raise("nope!")
+      allow(File).to receive(:exist?).with(Rails.root.join('db', 'test_track_schema.yml').to_s).and_return(false)
+      allow(YAML).to receive(:load_file).with(Rails.root.join('db', 'test_track_schema.yml').to_s).and_raise("no indeed!")
     end
 
     describe '#to_h' do


### PR DESCRIPTION
/domain @samandmoore @HipsterBrown
/platform @samandmoore 

I was relying on YAML.load_file to work like the previous code assumed it did (and had tests that made that assumption explicit). I was skeptical of this behavior at the time, but didn't do the research. :)

So here we go, better than ever - this used to blow up if you didn't have an old-school test track schema file too, instead of returning empty bags like the tests indicated.