### PR TITLE
Stub prefixed split names in stub_test_track_assignments

### DIFF
--- a/lib/test_track_rails_client/assignment_helper.rb
+++ b/lib/test_track_rails_client/assignment_helper.rb
@@ -7,14 +7,13 @@ module TestTrackRailsClient::AssignmentHelper
     app_name = URI.parse(TestTrack.private_url).user
 
     assignment_registry.each do |split_name, variant|
-      split_registry[split_name] = { variant => 100 } unless split_registry[split_name]
-      assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
-
-      next if split_name.to_s.include?('.')
-
       prefixed_split_name = "#{app_name}.#{split_name}"
-      split_registry[prefixed_split_name] = { variant => 100 } unless split_registry[prefixed_split_name]
-      assignments << { split_name: prefixed_split_name, variant: variant.to_s, unsynced: false }
+      if split_registry.key?(prefixed_split_name)
+        assignments << { split_name: prefixed_split_name, variant: variant.to_s, unsynced: false }
+      else
+        split_registry[split_name] = { variant => 100 } unless split_registry[split_name]
+        assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
+      end
     end
 
     visitor_attributes = { id: "fake_visitor_id", assignments: assignments }

--- a/lib/test_track_rails_client/assignment_helper.rb
+++ b/lib/test_track_rails_client/assignment_helper.rb
@@ -1,13 +1,20 @@
 module TestTrackRailsClient::AssignmentHelper
-  def stub_test_track_assignments(assignment_registry) # rubocop:disable Metrics/AbcSize
+  def stub_test_track_assignments(assignment_registry) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     raise "Cannot stub test track assignments when TestTrack is enabled" if TestTrack.enabled?
 
     split_registry = TestTrack::Fake::SplitRegistry.instance.to_h.dup
     assignments = []
+    app_name = URI.parse(TestTrack.private_url).user
 
     assignment_registry.each do |split_name, variant|
       split_registry[split_name] = { variant => 100 } unless split_registry[split_name]
       assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
+
+      next if split_name.to_s.include?('.')
+
+      prefixed_split_name = "#{app_name}.#{split_name}"
+      split_registry[prefixed_split_name] = { variant => 100 } unless split_registry[prefixed_split_name]
+      assignments << { split_name: prefixed_split_name, variant: variant.to_s, unsynced: false }
     end
 
     visitor_attributes = { id: "fake_visitor_id", assignments: assignments }

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "faraday", ">= 0.8", "< 1.0"
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
+  s.add_dependency 'multi_json', '~> 1.7'
   s.add_dependency 'public_suffix', '>= 2.0.0', '<= 3.0.0'
   s.add_dependency 'rails', '>= 4.1', "< 6.0"
   s.add_dependency 'request_store', '~> 1.3'


### PR DESCRIPTION
/domain @Betterment/test_track_core @effron 
/platform @smudge @jmileham @aburgel 

now that `vary` and `ab` auto-prefix split names (https://github.com/Betterment/test_track_rails_client/pull/72) it follows that `stub_test_track_assignments` should also auto-prefix the split names it stubs---so that a developer can stub using the same split name they pass to `vary` and `ab`.