### PR TITLE
Introduce a SplitRegistry model to avoid passing around hashes

### DIFF
--- a/app/models/test_track/ab_configuration.rb
+++ b/app/models/test_track/ab_configuration.rb
@@ -1,7 +1,7 @@
 class TestTrack::ABConfiguration
   include TestTrack::RequiredOptions
 
-  def initialize(opts)
+  def initialize(opts) # rubocop:disable Metrics/AbcSize
     @split_name = require_option!(opts, :split_name).to_s
     true_variant = require_option!(opts, :true_variant, allow_nil: true)
     @split_registry = require_option!(opts, :split_registry)

--- a/app/models/test_track/ab_configuration.rb
+++ b/app/models/test_track/ab_configuration.rb
@@ -4,12 +4,12 @@ class TestTrack::ABConfiguration
   def initialize(opts)
     @split_name = require_option!(opts, :split_name).to_s
     true_variant = require_option!(opts, :true_variant, allow_nil: true)
-    @split_registry = require_option!(opts, :split_registry, allow_nil: true)
+    @split_registry = require_option!(opts, :split_registry)
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 
     @true_variant = true_variant.to_s if true_variant
 
-    raise ArgumentError, unknown_split_error_message if @split_registry && !split
+    raise ArgumentError, unknown_split_error_message if @split_registry.loaded? && !split
   end
 
   def variants
@@ -42,11 +42,11 @@ class TestTrack::ABConfiguration
   end
 
   def split
-    split_registry && split_registry['splits'][split_name] && split_registry['splits'][split_name]['weights']
+    @split ||= split_registry.weights_for(split_name)
   end
 
   def split_variants
-    @split_variants ||= split.keys if split_registry
+    @split_variants ||= split.keys if split
   end
 
   def non_true_variants

--- a/app/models/test_track/fake/visitor.rb
+++ b/app/models/test_track/fake/visitor.rb
@@ -21,13 +21,13 @@ class TestTrack::Fake::Visitor
   end
 
   def split_registry
-    TestTrack::Fake::SplitRegistry.instance.to_h
+    TestTrack::SplitRegistry.new(TestTrack::Fake::SplitRegistry.instance.to_h)
   end
 
   private
 
   def _assignments
-    split_registry['splits'].keys.map do |split_name|
+    split_registry.split_names.map do |split_name|
       variant = TestTrack::VariantCalculator.new(visitor: self, split_name: split_name).variant
       Assignment.new(split_name, variant, false, "the_context")
     end

--- a/app/models/test_track/notify_assignment_job.rb
+++ b/app/models/test_track/notify_assignment_job.rb
@@ -44,11 +44,15 @@ class TestTrack::NotifyAssignmentJob
     experience_sampling_weight.zero?
   end
 
-  def experience_sampling_weight
-    @experience_sampling_weight ||= TestTrack::Remote::SplitRegistry.experience_sampling_weight
-  end
-
   def sample_event?
     Kernel.rand(experience_sampling_weight).zero?
+  end
+
+  def experience_sampling_weight
+    @experience_sampling_weight ||= split_registry.experience_sampling_weight
+  end
+
+  def split_registry
+    @split_registry ||= TestTrack::SplitRegistry.from_remote
   end
 end

--- a/app/models/test_track/remote/split_registry.rb
+++ b/app/models/test_track/remote/split_registry.rb
@@ -34,10 +34,6 @@ class TestTrack::Remote::SplitRegistry
       fetch_cache { nil } # cache the missing registry for 5 seconds if we can't get one
     end
 
-    def experience_sampling_weight
-      to_hash.fetch('experience_sampling_weight')
-    end
-
     private
 
     def fetch_cache(&block)

--- a/app/models/test_track/session.rb
+++ b/app/models/test_track/session.rb
@@ -31,7 +31,7 @@ class TestTrack::Session
       url: TestTrack.url,
       cookieDomain: cookie_domain,
       cookieName: visitor_cookie_name,
-      registry: current_visitor.v1_split_registry,
+      registry: current_visitor.split_registry.to_v1_hash,
       assignments: current_visitor.assignment_json
     }
   end

--- a/app/models/test_track/split_registry.rb
+++ b/app/models/test_track/split_registry.rb
@@ -1,0 +1,39 @@
+class TestTrack::SplitRegistry
+  def self.from_remote
+    new(TestTrack::Remote::SplitRegistry.to_hash)
+  end
+
+  def initialize(registry_hash)
+    @registry_hash = registry_hash
+  end
+
+  def include?(split_name)
+    registry_hash['splits'].key?(split_name)
+  end
+
+  def loaded?
+    registry_hash.present?
+  end
+
+  def split_names
+    registry_hash['splits'].keys
+  end
+
+  def experience_sampling_weight
+    registry_hash.fetch('experience_sampling_weight')
+  end
+
+  def weights_for(split_name)
+    registry_hash && registry_hash['splits'][split_name] && registry_hash['splits'][split_name]['weights']
+  end
+
+  def to_v1_hash
+    registry_hash && registry_hash['splits'].each_with_object({}) do |(k, v), result|
+      result[k] = v['weights']
+    end
+  end
+
+  private
+
+  attr_reader :registry_hash
+end

--- a/app/models/test_track/split_registry.rb
+++ b/app/models/test_track/split_registry.rb
@@ -24,7 +24,7 @@ class TestTrack::SplitRegistry
   end
 
   def weights_for(split_name)
-    registry_hash && registry_hash['splits'][split_name] && registry_hash['splits'][split_name]['weights']
+    registry_hash && registry_hash['splits'][split_name] && registry_hash['splits'][split_name]['weights'].freeze
   end
 
   def to_v1_hash

--- a/app/models/test_track/variant_calculator.rb
+++ b/app/models/test_track/variant_calculator.rb
@@ -32,7 +32,7 @@ class TestTrack::VariantCalculator
 
   def weighting
     @weighting ||= split_registry.weights_for(split_name) ||
-      (raise("TestTrack split '#{split_name}' not found. Need to write/run a migration?"))
+      raise("TestTrack split '#{split_name}' not found. Need to write/run a migration?")
   end
 
   def assignment_bucket

--- a/app/models/test_track/variant_calculator.rb
+++ b/app/models/test_track/variant_calculator.rb
@@ -14,7 +14,7 @@ class TestTrack::VariantCalculator
   end
 
   def variant
-    return nil unless split_registry
+    return nil unless split_registry.loaded?
     @variant ||= _variant || raise("Assignment bucket out of range. #{assignment_bucket} unmatched in #{split_name}: #{weighting}")
   end
 
@@ -31,8 +31,8 @@ class TestTrack::VariantCalculator
   end
 
   def weighting
-    @weighting ||= (split_registry['splits'][split_name] && split_registry['splits'][split_name]['weights']) ||
-      raise("TestTrack split '#{split_name}' not found. Need to write/run a migration?")
+    @weighting ||= split_registry.weights_for(split_name) ||
+      (raise("TestTrack split '#{split_name}' not found. Need to write/run a migration?"))
   end
 
   def assignment_bucket

--- a/app/models/test_track/vary_dsl.rb
+++ b/app/models/test_track/vary_dsl.rb
@@ -7,10 +7,10 @@ class TestTrack::VaryDSL
   def initialize(opts = {})
     @assignment = require_option!(opts, :assignment)
     @context = require_option!(opts, :context)
-    @split_registry = require_option!(opts, :split_registry, allow_nil: true)
+    @split_registry = require_option!(opts, :split_registry)
     raise ArgumentError, "unknown opts: #{opts.keys.to_sentence}" if opts.present?
 
-    if @split_registry && !split
+    if @split_registry.loaded? && !split
       raise ArgumentError, "unknown split: #{split_name}." \
         "#{' You may need to run rake test_track:schema:load.' if Rails.env.development?}"
     end
@@ -34,11 +34,11 @@ class TestTrack::VaryDSL
   delegate :split_name, to: :assignment
 
   def split
-    split_registry && split_registry['splits'][split_name] && split_registry['splits'][split_name]['weights']
+    @split ||= split_registry.weights_for(split_name)
   end
 
   def split_variants
-    @split_variants ||= split.keys if split_registry
+    @split_variants ||= split.keys if split
   end
 
   def notify_because_vary(msg)

--- a/app/models/test_track/visitor.rb
+++ b/app/models/test_track/visitor.rb
@@ -64,13 +64,7 @@ class TestTrack::Visitor
   end
 
   def split_registry
-    @split_registry ||= TestTrack::Remote::SplitRegistry.to_hash
-  end
-
-  def v1_split_registry
-    @v1_split_registry ||= split_registry && split_registry['splits'].each_with_object({}) do |(k, v), result|
-      result[k] = v['weights']
-    end
+    @split_registry ||= TestTrack::SplitRegistry.from_remote
   end
 
   def link_identity!(identity)
@@ -160,6 +154,6 @@ class TestTrack::Visitor
     app_name = URI.parse(TestTrack.private_url).user
     split_name = split_name.to_s
     prefixed = "#{app_name}.#{split_name}"
-    split_registry['splits'].key?(prefixed) ? prefixed : split_name
+    split_registry.include?(prefixed) ? prefixed : split_name
   end
 end

--- a/spec/models/test_track/ab_configuration_spec.rb
+++ b/spec/models/test_track/ab_configuration_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe TestTrack::ABConfiguration do
     }
   end
 
-  let(:split_registry) do
+  let(:split_registry) { TestTrack::SplitRegistry.new(split_registry_hash) }
+  let(:split_registry_hash) do
     {
       'splits' => {
         'button_color' => {
@@ -68,10 +69,10 @@ RSpec.describe TestTrack::ABConfiguration do
       }.to raise_error("unknown opts: unwelcome")
     end
 
-    it "allows a nil split_registry" do
+    it "raises when given a nil split_registry" do
       expect {
         described_class.new initialize_options.merge(split_registry: nil)
-      }.not_to raise_error
+      }.to raise_error("Must provide split_registry")
     end
 
     it "raises a descriptive error when the split is not in the split_registry" do
@@ -130,8 +131,8 @@ RSpec.describe TestTrack::ABConfiguration do
         expect(subject.variants).to include(false: "blue")
       end
 
-      it "is false when there is no split_registry" do
-        ab_configuration = described_class.new initialize_options.merge(split_registry: nil)
+      it "is false when there is an unloaded split_registry" do
+        ab_configuration = described_class.new initialize_options.merge(split_registry: TestTrack::SplitRegistry.new(nil))
         expect(ab_configuration.variants).to include(false: false)
       end
 

--- a/spec/models/test_track/notify_assignment_job_spec.rb
+++ b/spec/models/test_track/notify_assignment_job_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe TestTrack::NotifyAssignmentJob do
 
   describe "#perform" do
     let(:remote_assignment) { instance_double(TestTrack::Remote::AssignmentEvent) }
+    let(:split_registry) { instance_double(TestTrack::SplitRegistry, experience_sampling_weight: 1) }
     before do
+      allow(TestTrack::SplitRegistry).to receive(:from_remote).and_return(split_registry)
       allow(TestTrack::Remote::AssignmentEvent).to receive(:create!).and_return(remote_assignment)
       allow(TestTrack.analytics).to receive(:track).and_return(true)
     end
@@ -73,7 +75,7 @@ RSpec.describe TestTrack::NotifyAssignmentJob do
     end
 
     it "sends analytics events when feature gate events are disabled" do
-      allow(TestTrack::Remote::SplitRegistry).to receive(:experience_sampling_weight).and_return(0)
+      allow(split_registry).to receive(:experience_sampling_weight).and_return(0)
 
       with_test_track_enabled { subject.perform }
 
@@ -115,7 +117,7 @@ RSpec.describe TestTrack::NotifyAssignmentJob do
       end
 
       it "doesn't send analytics events when feature gate events are disabled" do
-        allow(TestTrack::Remote::SplitRegistry).to receive(:experience_sampling_weight).and_return(0)
+        allow(split_registry).to receive(:experience_sampling_weight).and_return(0)
 
         with_test_track_enabled { subject.perform }
 

--- a/spec/models/test_track/session_spec.rb
+++ b/spec/models/test_track/session_spec.rb
@@ -518,9 +518,11 @@ RSpec.describe TestTrack::Session do
       }
     end
 
-    let(:visitor) { instance_double(TestTrack::Visitor, v1_split_registry: v1_split_registry, assignment_json: "assignments") }
+    let(:split_registry) { instance_double(TestTrack::SplitRegistry) }
+    let(:visitor) { instance_double(TestTrack::Visitor, split_registry: split_registry, assignment_json: "assignments") }
     before do
       allow(subject).to receive(:current_visitor).and_return(visitor)
+      allow(split_registry).to receive(:to_v1_hash).and_return(v1_split_registry)
     end
 
     it "includes the test track URL" do
@@ -545,7 +547,7 @@ RSpec.describe TestTrack::Session do
     end
 
     it "includes a nil :registry if visitor returns a nil split_registry" do
-      allow(visitor).to receive(:v1_split_registry).and_return(nil)
+      allow(split_registry).to receive(:to_v1_hash).and_return(nil)
       expect(subject.state_hash).to have_key(:registry)
       expect(subject.state_hash[:registry]).to eq(nil)
     end

--- a/spec/models/test_track/split_registry_spec.rb
+++ b/spec/models/test_track/split_registry_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.describe TestTrack::SplitRegistry do
+  subject { described_class.new(registry_hash) }
+
+  let(:registry_hash) do
+    {
+      'splits' => {
+        'button_size' => {
+          'weights' => {
+            'one' => 50,
+            'two' => 50
+          },
+          'feature_gate' => 'false'
+        },
+        'time' => {
+          'weights' => {
+            'hammertime' => 100,
+            'clobberin_time' => 0
+          },
+          'feature_gate' => 'false'
+        }
+      },
+      'experience_sampling_weight' => 1
+    }
+  end
+
+  describe ".from_remote" do
+    context "with a server response" do
+      before do
+        allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(registry_hash)
+      end
+
+      it "returns an instance populated with a remote hash" do
+        split_registry = described_class.from_remote
+
+        expect(split_registry).to be_an_instance_of(TestTrack::SplitRegistry)
+        expect(split_registry.loaded?).to eq(true)
+        expect(TestTrack::Remote::SplitRegistry).to have_received(:to_hash)
+      end
+    end
+
+    context "with a nil hash" do
+      before do
+        allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(nil)
+      end
+
+      it "returns an instance populated with a remote hash" do
+        split_registry = described_class.from_remote
+
+        expect(split_registry).to be_an_instance_of(TestTrack::SplitRegistry)
+        expect(split_registry.loaded?).to eq(false)
+        expect(TestTrack::Remote::SplitRegistry).to have_received(:to_hash)
+      end
+    end
+  end
+
+  describe "#include?" do
+    it "returns true when a split with the given name is present in the registry" do
+      expect(subject.include?('time')).to eq true
+      expect(subject.include?('not_time')).to eq false
+    end
+  end
+
+  describe "#loaded?" do
+    context "when registry is present" do
+      it "returns true" do
+        expect(subject.loaded?).to eq true
+      end
+    end
+
+    context "when no registry is available" do
+      let(:registry_hash) { nil }
+
+      it "returns false" do
+        expect(subject.loaded?).to eq false
+      end
+    end
+  end
+
+  describe "#split_names" do
+    it "returns list of split names" do
+      expect(subject.split_names).to contain_exactly('button_size', 'time')
+    end
+  end
+
+  describe "#experience_sampling_weight" do
+    it "returns sampling weight provided by server" do
+      expect(subject.experience_sampling_weight).to eq(1)
+    end
+  end
+
+  describe "#weights_for" do
+    it "returns weights for the given split" do
+      expect(subject.weights_for('time')).to eq("clobberin_time" => 0, "hammertime" => 100)
+      expect(subject.weights_for('no_time')).to eq(nil)
+    end
+  end
+
+  describe "#to_v1_hash" do
+    it "returns a hash compatible with v1 split registry endpoint" do
+      expect(subject.to_v1_hash).to eq(
+        "button_size" => {
+          "one" => 50,
+          "two" => 50
+        },
+        "time" => {
+          "clobberin_time" => 0,
+          "hammertime" => 100
+        }
+      )
+    end
+  end
+end

--- a/spec/models/test_track/variant_calculator_spec.rb
+++ b/spec/models/test_track/variant_calculator_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe TestTrack::VariantCalculator do
 
   let(:fake_visitor_id) { "00000000-0000-0000-0000-000000000000" }
 
-  let(:split_registry) do
+  let(:split_registry) { TestTrack::SplitRegistry.new(split_registry_hash) }
+  let(:split_registry_hash) do
     {
       'splits' => {
         'blue_button' => {
@@ -100,7 +101,7 @@ RSpec.describe TestTrack::VariantCalculator do
 
   describe "#variant" do
     context "with a nil split_registry" do
-      let(:split_registry) { nil }
+      let(:split_registry_hash) { nil }
 
       it "returns nil if split registry isn't present" do
         expect(subject.variant).to eq nil
@@ -108,7 +109,7 @@ RSpec.describe TestTrack::VariantCalculator do
     end
 
     context "in logo_size split" do
-      let(:split_registry) do
+      let(:split_registry_hash) do
         {
           'splits' => {
             'logo_size' => {
@@ -146,7 +147,7 @@ RSpec.describe TestTrack::VariantCalculator do
     end
 
     context "with an incomplete weighting" do
-      let(:split_registry) do
+      let(:split_registry_hash) do
         {
           'splits' => {
             'invalid_weighting' => {

--- a/spec/models/test_track/vary_dsl_spec.rb
+++ b/spec/models/test_track/vary_dsl_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe TestTrack::VaryDSL do
   let(:assignment) do
     instance_double(TestTrack::Assignment, split_name: "button_size", variant: "one")
   end
-  let(:split_registry) do
+  let(:split_registry) { TestTrack::SplitRegistry.new(split_registry_hash) }
+  let(:split_registry_hash) do
     {
       'splits' => {
         'button_size' => {
@@ -106,8 +107,8 @@ RSpec.describe TestTrack::VaryDSL do
       expect(notifier).to have_received(:notify).with("vary for \"button_size\" does not configure variants three and four")
     end
 
-    context "with a nil split_registry" do
-      let(:split_registry) { nil }
+    context "with an unloaded split_registry" do
+      let(:split_registry_hash) { nil }
 
       before do
         subject.when(:one) { "hello!" }
@@ -170,7 +171,7 @@ RSpec.describe TestTrack::VaryDSL do
     end
 
     context "with a nil split_registry" do
-      let(:split_registry) { nil }
+      let(:split_registry_hash) { nil }
 
       it "assumes all variants are valid" do
         subject.when :something_random, &noop
@@ -218,7 +219,7 @@ RSpec.describe TestTrack::VaryDSL do
     end
 
     context "with a nil split_registry" do
-      let(:split_registry) { nil }
+      let(:split_registry_hash) { nil }
 
       it "assumes all variants are valid" do
         subject.default :something_random, &noop


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

A follow on to #82 (and mostly based on @jmileham's work that he reverted in #58). ~~I'm keeping this in draft mode until #82 lands. I think I need to add a few more specs too.~~

TODO
- [x] Run against an app's test suite