### PR TITLE
Always stub split registry in stub_test_track_assignments

### DIFF
--- a/lib/test_track_rails_client/assignment_helper.rb
+++ b/lib/test_track_rails_client/assignment_helper.rb
@@ -8,10 +8,17 @@ module TestTrackRailsClient::AssignmentHelper
 
     assignment_registry.each do |split_name, variant|
       prefixed_split_name = "#{app_name}.#{split_name}"
-      split_name = prefixed_split_name if split_registry['splits'].key?(prefixed_split_name)
+      split_name = if split_registry['splits'].key?(prefixed_split_name)
+                     prefixed_split_name
+                   else
+                     split_name.to_s
+                   end
 
-      split_registry['splits'][split_name.to_s] = { weights: { variant.to_s => 100 }, feature_gate: false }
-      assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
+      split_registry['splits'][split_name] = {
+        weights: { variant.to_s => 100 },
+        feature_gate: split_name.end_with?('_enabled')
+      }
+      assignments << { split_name: split_name, variant: variant.to_s, unsynced: false }
     end
 
     visitor_attributes = { id: "fake_visitor_id", assignments: assignments }

--- a/lib/test_track_rails_client/assignment_helper.rb
+++ b/lib/test_track_rails_client/assignment_helper.rb
@@ -8,14 +8,10 @@ module TestTrackRailsClient::AssignmentHelper
 
     assignment_registry.each do |split_name, variant|
       prefixed_split_name = "#{app_name}.#{split_name}"
-      if split_registry['splits'].key?(prefixed_split_name)
-        assignments << { split_name: prefixed_split_name, variant: variant.to_s, unsynced: false }
-      else
-        unless split_registry['splits'][split_name]
-          split_registry['splits'][split_name.to_s] = { weights: { variant.to_s => 100 }, feature_gate: false }
-        end
-        assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
-      end
+      split_name = prefixed_split_name if split_registry['splits'].key?(prefixed_split_name)
+
+      split_registry['splits'][split_name.to_s] = { weights: { variant.to_s => 100 }, feature_gate: false }
+      assignments << { split_name: split_name.to_s, variant: variant.to_s, unsynced: false }
     end
 
     visitor_attributes = { id: "fake_visitor_id", assignments: assignments }

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha27" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha28" # rubocop:disable Style/MutableConstant
 end

--- a/spec/assignment_helper_spec.rb
+++ b/spec/assignment_helper_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe TestTrackRailsClient::AssignmentHelper do
       )
     end
 
+    it 'sets feature_gate based on the split name' do
+      stub_test_track_assignments(foo_enabled: :bar)
+
+      expect(TestTrack::Remote::SplitRegistry.to_hash['splits']).to include(
+        'foo_enabled' => { 'weights' => { 'bar' => 100 }, 'feature_gate' => true }
+      )
+    end
+
     context 'with a prefixed split name already in the split registry' do
       let(:fake_split_registry) do
         instance_double(TestTrack::Fake::SplitRegistry, to_h: { 'splits' => { 'dummy.foo' => { 'weights' => { 'bar' => 100 } } } })

--- a/spec/assignment_helper_spec.rb
+++ b/spec/assignment_helper_spec.rb
@@ -27,13 +27,17 @@ RSpec.describe TestTrackRailsClient::AssignmentHelper do
 
       before { allow(TestTrack::Fake::SplitRegistry).to receive(:instance).and_return(fake_split_registry) }
 
-      it 'overrides assignment registry to match' do
+      it 'overrides assignment registry to match and overrides split registry' do
         stub_test_track_assignments(foo: :bar)
 
         TestTrack::Remote::Visitor.find(201).assignments.first.tap do |assignment|
           expect(assignment.split_name).to eq('dummy.foo')
           expect(assignment.variant).to eq('bar')
         end
+
+        expect(TestTrack::Remote::SplitRegistry.to_hash['splits']).to include(
+          'dummy.foo' => { 'weights' => { 'bar' => 100 }, 'feature_gate' => false }
+        )
       end
     end
 


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

Tracked down some unexpected behavior with the stubbing of prefixed vs non-prefixed split names...

In the conditional where we'd append a prefix to a passed in un-prefixed split name, we were only stubbing visitor assignments, whereas the other side of the conditional would stub both visitor assignments and override weights in the split registry. It turns out the overriding of the split registry is important in contexts where there is no pre-existing visitor (e.g. an unauthenticated context which will generate a new visitor). In that case, assignments are not used (see https://github.com/Betterment/test_track_rails_client/blob/master/app/models/test_track/visitor.rb#L13) so overriding the split registry is the only means by which we can actually stub the generated assignment.
