### PR TITLE
 Add an escape hatch for skipping TT CLI schema/migrate rake tasks

### DIFF
--- a/app/models/testtrack_cli.rb
+++ b/app/models/testtrack_cli.rb
@@ -3,6 +3,12 @@ require 'rbconfig'
 class TesttrackCli
   include Singleton
 
+  def skip_testtrack_cli?
+    Rails.env.test? ||
+      (Rails.env.development? && !project_initialized?) ||
+      ENV['SKIP_TESTTRACK_CLI'].present?
+  end
+
   def project_initialized?
     File.exist?(File.join('testtrack', 'schema.yml'))
   end

--- a/app/models/testtrack_cli.rb
+++ b/app/models/testtrack_cli.rb
@@ -4,9 +4,7 @@ class TesttrackCli
   include Singleton
 
   def skip_testtrack_cli?
-    Rails.env.test? ||
-      (Rails.env.development? && !project_initialized?) ||
-      ENV['SKIP_TESTTRACK_CLI'].present?
+    Rails.env.test? || (Rails.env.development? && project_initialized?) || ENV['SKIP_TESTTRACK_CLI'].present?
   end
 
   def project_initialized?

--- a/app/models/testtrack_cli.rb
+++ b/app/models/testtrack_cli.rb
@@ -4,7 +4,7 @@ class TesttrackCli
   include Singleton
 
   def skip_testtrack_cli?
-    Rails.env.test? || (Rails.env.development? && project_initialized?) || ENV['SKIP_TESTTRACK_CLI'].present?
+    Rails.env.test? || (Rails.env.development? && project_initialized?) || ENV.key?('SKIP_TESTTRACK_CLI')
   end
 
   def project_initialized?

--- a/lib/tasks/test_track_rails_client_tasks.rake
+++ b/lib/tasks/test_track_rails_client_tasks.rake
@@ -2,6 +2,7 @@ namespace :test_track do
   desc 'Run outstanding TestTrack migrations'
   task migrate: :environment do
     cli = TesttrackCli.instance
+    next if cli.skip_testtrack_cli?
 
     if cli.project_initialized?
       result = cli.call('migrate')
@@ -13,6 +14,7 @@ namespace :test_track do
     desc 'Load schema.yml state into TestTrack server'
     task load: :environment do
       cli = TesttrackCli.instance
+      next if cli.skip_testtrack_cli?
 
       if cli.project_initialized?
         result = cli.call('schema', 'load')
@@ -26,8 +28,6 @@ namespace :test_track do
   end
 end
 
-if !Rails.env.test? && !(Rails.env.development? && File.exist?(File.join('testtrack', 'schema.yml')))
-  task 'db:schema:load' => ['test_track:schema:load']
-  task 'db:structure:load' => ['test_track:schema:load']
-  task 'db:migrate' => ['test_track:migrate']
-end
+task 'db:schema:load' => ['test_track:schema:load']
+task 'db:structure:load' => ['test_track:schema:load']
+task 'db:migrate' => ['test_track:migrate']

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha28" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha29" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/testtrack_cli_spec.rb
+++ b/spec/models/testtrack_cli_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TesttrackCli do
     before do |example|
       mock_env = example.metadata[:env] || 'production'
       allow(Rails).to receive(:env) { mock_env.inquiry }
-      allow(ENV).to receive(:[]).with('SKIP_TESTTRACK_CLI') { '1' } if example.metadata[:env_skip]
+      allow(ENV).to receive(:key?).with('SKIP_TESTTRACK_CLI') { true } if example.metadata[:env_skip]
       allow(TesttrackCli.instance).to receive(:project_initialized?) { example.metadata[:project_initialized].present? }
     end
 

--- a/spec/models/testtrack_cli_spec.rb
+++ b/spec/models/testtrack_cli_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe TesttrackCli do
+  describe '#skip_testtrack_cli?' do
+    subject { TesttrackCli.instance.skip_testtrack_cli? }
+
+    before do |example|
+      mock_env = example.metadata[:env] || 'production'
+      allow(Rails).to receive(:env) { mock_env.inquiry }
+      allow(ENV).to receive(:[]).with('SKIP_TESTTRACK_CLI') { '1' } if example.metadata[:env_skip]
+      allow(TesttrackCli.instance).to receive(:project_initialized?) { example.metadata[:project_initialized].present? }
+    end
+
+    it { is_expected.to eq(false) }
+
+    context 'SKIP_TESTTRACK_CLI=1', env_skip: true do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'Rails.env.test?', env: 'test' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'project_initialized?', project_initialized: true do
+      it { is_expected.to eq(false) }
+
+      context 'SKIP_TESTTRACK_CLI=1', env_skip: true do
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    context 'Rails.env.development?', env: 'development' do
+      it { is_expected.to eq(false) }
+
+      context 'project_initialized?', project_initialized: true do
+        it { is_expected.to eq(true) }
+      end
+
+      context 'SKIP_TESTTRACK_CLI=1', env_skip: true do
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/platform @jmileham 

I made the choice to pull the giant conditional out into a method on the singleton, but since `TesttrackCli` isn't loaded yet at the top level of the rake task, I pulled the escape hatch down into a guard clause in the actual task blocks.