### PR TITLE
Accept a class name, not an instance reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,11 @@ TestTrack provides hooks to easily integrate with your preferred error catching 
 
 ```ruby
 # config/initializers/test_track.rb
-TestTrack.misconfiguration_notifier = MyCustomMisconfigurationNotifier.new
+TestTrack.misconfiguration_notifier_class_name = 'MyCustomMisconfigurationNotifier'
 ```
 
-Your client must implement the following methods:
+Your client must be a class that can be instantiated with no arguments,
+and implement the following methods:
 
 ```ruby
 # Called when a Split misconfiguration is detected

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -29,18 +29,23 @@ module TestTrack
     end
 
     def misconfiguration_notifier
-      @misconfiguration_notifier ||= TestTrack::MisconfigurationNotifier::Wrapper.new(default_notifier)
+      TestTrack::MisconfigurationNotifier::Wrapper.new(new_misconfiguration_notifier || default_notifier)
     end
 
-    def misconfiguration_notifier=(notifier)
-      @misconfiguration_notifier = if notifier.is_a?(TestTrack::MisconfigurationNotifier::Wrapper)
-                                     notifier
-                                   else
-                                     TestTrack::MisconfigurationNotifier::Wrapper.new(notifier)
-                                   end
+    def misconfiguration_notifier_class_name=(notifier_class_name)
+      begin
+        notifier_class_name.constantize.new
+      rescue StandardError
+        raise "misconfiguration_notifier #{notifier_name} must be a class that can be instantiated without arguments"
+      end
+      @misconfiguration_notifier_class_name = notifier_class_name
     end
 
     private
+
+    def new_misconfiguration_notifier
+      @misconfiguration_notifier_class_name&.constantize&.new
+    end
 
     def default_notifier
       if defined?(::Airbrake)

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -68,36 +68,51 @@ RSpec.describe TestTrack do
   end
 
   describe "misconfguration_notifier" do
-    it "wraps a custom notifier in Wrapper" do
+    it "wraps a custom notifier in Wrapper without memoizing" do
       begin
-        default_notifier = TestTrack.misconfiguration_notifier
         fake_notifier = double
-        TestTrack.misconfiguration_notifier = fake_notifier
-        expect(TestTrack.misconfiguration_notifier.class).to eq TestTrack::MisconfigurationNotifier::Wrapper
+        fake_notifier_class = double(new: fake_notifier)
+        stub_const('FakeNotifier', fake_notifier_class)
+        TestTrack.misconfiguration_notifier_class_name = 'FakeNotifier'
+
+        expect(TestTrack.misconfiguration_notifier).to be_instance_of(TestTrack::MisconfigurationNotifier::Wrapper)
         expect(TestTrack.misconfiguration_notifier.underlying).to eq fake_notifier
       ensure
-        TestTrack.misconfiguration_notifier = default_notifier
+        TestTrack.instance_variable_set(:@misconfiguration_notifier_class_name, nil)
+      end
+    end
+
+    it "returns a new instance each time" do
+      begin
+        fake_notifier = double
+        fake_notifier_class = double
+        call_count = 0
+        allow(fake_notifier_class).to receive(:new) do
+          call_count += 1
+          fake_notifier
+        end
+        stub_const('FakeNotifier', fake_notifier_class)
+        TestTrack.misconfiguration_notifier_class_name = 'FakeNotifier'
+
+        expect {
+          3.times { TestTrack.misconfiguration_notifier }
+        }.to change { call_count }.by(3)
+      ensure
+        TestTrack.instance_variable_set(:@misconfiguration_notifier_class_name, nil)
+      end
+    end
+
+    context "when Airbrake is defined" do
+      it "defaults Airbrake notifier without memoizing" do
+        expect(TestTrack.misconfiguration_notifier.underlying.class).to eq TestTrack::MisconfigurationNotifier::Null
+        stub_const("Airbrake", double("Airbrake"))
+        expect(TestTrack.misconfiguration_notifier.underlying.class).to eq TestTrack::MisconfigurationNotifier::Airbrake
       end
     end
 
     it "defaults to null notifier" do
       expect(TestTrack.misconfiguration_notifier.class).to eq TestTrack::MisconfigurationNotifier::Wrapper
       expect(TestTrack.misconfiguration_notifier.underlying.class).to eq TestTrack::MisconfigurationNotifier::Null
-    end
-
-    context "when Airbrake is defined" do
-      it "defaults Airbrake notifier" do
-        begin
-          default_notifier = TestTrack.misconfiguration_notifier
-          stub_const("Airbrake", double("Airbrake"))
-          if TestTrack.instance_variable_defined?(:@misconfiguration_notifier)
-            TestTrack.remove_instance_variable(:@misconfiguration_notifier)
-          end
-          expect(TestTrack.misconfiguration_notifier.underlying.class).to eq TestTrack::MisconfigurationNotifier::Airbrake
-        ensure
-          TestTrack.misconfiguration_notifier = default_notifier
-        end
-      end
     end
   end
 


### PR DESCRIPTION
Prevents class cache nonsense when used with spring by reifying a fresh
instance on each call.

In usage, this value is ephemerally memoized in VaryDSL and ABConfiguration instances, which are short lived, so we should be fine. Slight reduction in performance when we find a misconfigured split, but that seems fine steady state, especially since we've never profiled this code or optimized it to begin with.

I think this config option was introduced in an alpha, so this shouldn't require bumping version beyond yet-another-alpha. I think we're getting close to cutting an RC, finally.

/domain @samandmoore
/platform @samandmoore