### PR TITLE
Allow job session to be reentrant

### DIFF
--- a/app/models/test_track/job_session.rb
+++ b/app/models/test_track/job_session.rb
@@ -1,7 +1,6 @@
 class TestTrack::JobSession
   def manage
     raise ArgumentError, "must provide block to `manage`" unless block_given?
-    raise "already in use" unless RequestStore[:test_track_job_session].nil?
 
     RequestStore[:test_track_job_session] = self
     yield

--- a/app/models/test_track/job_session.rb
+++ b/app/models/test_track/job_session.rb
@@ -2,11 +2,12 @@ class TestTrack::JobSession
   def manage
     raise ArgumentError, "must provide block to `manage`" unless block_given?
 
+    original_job_session = RequestStore[:test_track_job_session]
     RequestStore[:test_track_job_session] = self
     yield
   ensure
     notify_unsynced_assignments!
-    RequestStore[:test_track_job_session] = nil
+    RequestStore[:test_track_job_session] = original_job_session
   end
 
   def visitor_dsl_for(identity)

--- a/lib/test_track/delayed_job/job_session_plugin.rb
+++ b/lib/test_track/delayed_job/job_session_plugin.rb
@@ -1,5 +1,5 @@
-module Delayed
-  module Plugins
+module TestTrack
+  module DelayedJob
     class JobSessionPlugin < Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha30" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha31" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/job_session_spec.rb
+++ b/spec/models/test_track/job_session_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe TestTrack::JobSession do
       expect { subject.manage }.to raise_error 'must provide block to `manage`'
     end
 
-    it 'may not be called within itself' do
-      subject.manage do
-        expect { subject.manage {} }.to raise_error 'already in use'
-      end
-    end
-
     context 'assignment notification' do
       let(:visitor_notifier) { instance_double(TestTrack::ThreadedVisitorNotifier, notify: true) }
 

--- a/spec/models/test_track/job_session_spec.rb
+++ b/spec/models/test_track/job_session_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe TestTrack::JobSession do
         inner_session = described_class.new
         inner_session.manage do
           expect(RequestStore[:test_track_job_session]).to eq inner_session
+          expect(inner_session).not_to eq subject
         end
         expect(RequestStore[:test_track_job_session]).to eq subject
       end

--- a/spec/models/test_track/job_session_spec.rb
+++ b/spec/models/test_track/job_session_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe TestTrack::JobSession do
       expect { subject.manage }.to raise_error 'must provide block to `manage`'
     end
 
+    it 'maintains itself in the request store' do
+      expect(RequestStore[:test_track_job_session]).to be_nil
+
+      subject.manage do
+        expect(RequestStore[:test_track_job_session]).to eq subject
+
+        inner_session = described_class.new
+        inner_session.manage do
+          expect(RequestStore[:test_track_job_session]).to eq inner_session
+        end
+        expect(RequestStore[:test_track_job_session]).to eq subject
+      end
+
+      expect(RequestStore[:test_track_job_session]).to be_nil
+    end
+
     context 'assignment notification' do
       let(:visitor_notifier) { instance_double(TestTrack::ThreadedVisitorNotifier, notify: true) }
 


### PR DESCRIPTION
/domain @jmileham @smudge @samandmoore 
/no-platform

Further testing of #84 revealed that running DJ in synchronous mode (during tests) causes plugins to be executed on each invocation. So if you have a job the runs another job, you'll have plugins running within plugins. So the extra bit of safety I added to prevent misuse is too restrictive.

I've modified the job plugin to allow reentrancy. If this were to occur in production, you'd lose some efficiency of visitor caching, but you would not lose correctness.