### PR TITLE
Fix CLI failures when English module is missing

### DIFF
--- a/app/models/testtrack_cli.rb
+++ b/app/models/testtrack_cli.rb
@@ -1,4 +1,5 @@
 require 'rbconfig'
+require 'English'
 
 class TesttrackCli
   include Singleton

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha31" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha32" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/testtrack_cli_spec.rb
+++ b/spec/models/testtrack_cli_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe TesttrackCli do
+  describe '#call' do
+    it 'calls the CLI' do
+      expect(TesttrackCli.instance.call('--version')).to be_success
+    end
+  end
+
   describe '#skip_testtrack_cli?' do
     subject { TesttrackCli.instance.skip_testtrack_cli? }
 


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform
/cc @joejansen @fidelscodes

`TesttrackCli` module makes use of `$CHILD_STATUS`, which is provided by the `English` module. We weren't explicitly requiring it, so the code only happened to work because many gems `require 'English'` for their own purposes. The airbrake gem, which we carried as a dependency up until recently, is one example. If you're unlucky enough to not use such a gem, then `$CHILD_STATUS` will always be nil and blow up in our usecase.

I added a test that runs the CLI via `TesttrackCli`, hoping that it would fail, but it turns out that `simplecov` gem does a `require 'English'`, so `TesttrackCli#call` succeeds. I'm going to leave the test in anyways, since its a useful integration test.