### PR TITLE
Add special case for localhost cookie

### DIFF
--- a/app/models/test_track/web_session.rb
+++ b/app/models/test_track/web_session.rb
@@ -94,7 +94,7 @@ class TestTrack::WebSession
   end
 
   def _cookie_domain
-    if bare_ip_address? || fully_qualified_cookie_domain_enabled?
+    if bare_ip_address? || request.local? || fully_qualified_cookie_domain_enabled?
       request.host
     else
       wildcard_domain

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.0.alpha34" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.0.alpha35" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/web_session_spec.rb
+++ b/spec/models/test_track/web_session_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe TestTrack::WebSession do
 
   let(:cookies) { { tt_visitor_id: "fake_visitor_id" }.with_indifferent_access }
   let(:headers) { {} }
-  let(:request) { double(:request, host: "www.foo.com", ssl?: true, headers: headers, local?: local_request?) }
-  let(:local_request?) { false }
+  let(:request) { double(:request, host: "www.foo.com", ssl?: true, headers: headers, local?: local?) }
+  let(:local?) { false }
   let(:response) { double(:response, headers: {}) }
   let(:unsynced_assignments_notifier) { instance_double(TestTrack::UnsyncedAssignmentsNotifier, notify: true) }
 
@@ -222,7 +222,7 @@ RSpec.describe TestTrack::WebSession do
       end
 
       context 'when request is local' do
-        let(:local_request?) { true }
+        let(:local?) { true }
 
         it 'uses localhost as cookie domain' do
           allow(request).to receive(:host).and_return("localhost")

--- a/spec/models/test_track/web_session_spec.rb
+++ b/spec/models/test_track/web_session_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe TestTrack::WebSession do
 
   let(:cookies) { { tt_visitor_id: "fake_visitor_id" }.with_indifferent_access }
   let(:headers) { {} }
-  let(:request) { double(:request, host: "www.foo.com", ssl?: true, headers: headers) }
+  let(:request) { double(:request, host: "www.foo.com", ssl?: true, headers: headers, local?: local_request?) }
+  let(:local_request?) { false }
   let(:response) { double(:response, headers: {}) }
   let(:unsynced_assignments_notifier) { instance_double(TestTrack::UnsyncedAssignmentsNotifier, notify: true) }
 
@@ -218,6 +219,16 @@ RSpec.describe TestTrack::WebSession do
         allow(request).to receive(:host).and_return("foo.bar.baz.boom.com")
         subject.manage {}
         expect(cookies['tt_visitor_id'][:domain]).to eq ".boom.com"
+      end
+
+      context 'when request is local' do
+        let(:local_request?) { true }
+
+        it 'uses localhost as cookie domain' do
+          allow(request).to receive(:host).and_return("localhost")
+          subject.manage {}
+          expect(cookies['tt_visitor_id'][:domain]).to eq 'localhost'
+        end
       end
 
       it "uses the fully qualified cookie domain when enabled and there is no subdomain" do


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/platform @aburgel @jmileham 
/cc @Betterment/security 

Adding a special case for localhost when setting the test track cookie domain. Currently, the cookie domain is set to `.localhost`, which is invalid in chrome and leads to all assignments reverting to the default. This is only a problem for developers using `rails s` instead of pow for local application development.