### PR TITLE
Rework/simplify development dependencies

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,18 +1,13 @@
 appraise 'rails-5-1' do
   gem 'rails', '~> 5.1.0'
-  gem 'rack'
-  gem 'rails-controller-testing'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 appraise 'rails-5-2' do
   gem 'rails', '~> 5.2.0'
-  gem 'rack'
-  gem 'rails-controller-testing'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 appraise 'rails-6-0' do
   gem 'rails', '~> 6.0.0'
-  gem 'rack'
-  gem 'rails-controller-testing'
-  gem 'sqlite3', '~> 1.4'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,8 @@
 source "https://rubygems.org"
 ruby '>= 2.1.0'
 
+# Required for, e.g., show.json.jbuilder to work
+# see: https://github.com/rails/jbuilder/issues/346
+gem 'jbuilder'
+
 gemspec
-
-gem 'rubocop', '~> 0.61.0', require: false
-
-gem 'simplecov', require: false
-gem 'shoulda-matchers', '~> 2.8', require: false
-gem 'jbuilder', '~> 2.0'
-gem 'mime-types', '< 3'
-gem 'selenium-webdriver', '~> 2.5'
-
-gem 'rspec-rails'
-
-gem 'rack'
-
-gem 'sqlite3', '~> 1.3.6'
-
-gem 'nokogiri', '~> 1.8.2'
-gem 'webmock', '< 2.3.1'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -4,18 +4,8 @@ source "https://rubygems.org"
 
 ruby ">= 2.1.0"
 
-gem "jbuilder", "~> 2.0"
-gem "mime-types", "< 3"
-gem "nokogiri", "~> 1.8.2"
-gem "rack"
+gem "jbuilder"
 gem "rails", "~> 5.1.0"
-gem "rails-controller-testing"
-gem "rspec-rails"
-gem "rubocop", "~> 0.61.0", require: false
-gem "selenium-webdriver", "~> 2.5"
-gem "shoulda-matchers", "~> 2.8", require: false
-gem "simplecov", require: false
 gem "sqlite3", "~> 1.3.6"
-gem "webmock", "< 2.3.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -4,18 +4,8 @@ source "https://rubygems.org"
 
 ruby ">= 2.1.0"
 
-gem "jbuilder", "~> 2.0"
-gem "mime-types", "< 3"
-gem "nokogiri", "~> 1.8.2"
-gem "rack"
+gem "jbuilder"
 gem "rails", "~> 5.2.0"
-gem "rails-controller-testing"
-gem "rspec-rails"
-gem "rubocop", "~> 0.61.0", require: false
-gem "selenium-webdriver", "~> 2.5"
-gem "shoulda-matchers", "~> 2.8", require: false
-gem "simplecov", require: false
 gem "sqlite3", "~> 1.3.6"
-gem "webmock", "< 2.3.1"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -4,18 +4,7 @@ source "https://rubygems.org"
 
 ruby ">= 2.1.0"
 
-gem "jbuilder", "~> 2.0"
-gem "mime-types", "< 3"
-gem "nokogiri", "~> 1.8.2"
-gem "rack"
+gem "jbuilder"
 gem "rails", "~> 6.0.0"
-gem "rails-controller-testing"
-gem "rspec-rails"
-gem "rubocop", "~> 0.61.0", require: false
-gem "selenium-webdriver", "~> 2.5"
-gem "shoulda-matchers", "~> 2.8", require: false
-gem "simplecov", require: false
-gem "sqlite3", "~> 1.4"
-gem "webmock", "< 2.3.1"
 
 gemspec path: "../"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,13 +4,14 @@ require File.expand_path('dummy/config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
+require 'rails-controller-testing'
 require 'rspec/rails'
-require 'shoulda/matchers'
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'timecop'
 require 'delayed_job'
 require 'delayed_job_active_record'
 require 'pry'
+require 'shoulda/matchers'
+require 'timecop'
 
 # load all files in support folders
 Dir[TestTrackRailsClient::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -26,10 +26,16 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '>= 4.1', "< 7.0"
   s.add_dependency 'request_store', '~> 1.3'
 
-  s.add_development_dependency 'appraisal', '~> 2.2.0'
-  s.add_development_dependency "pry-rails"
-  s.add_development_dependency "timecop"
-  s.add_development_dependency "webmock", "~> 2.1.0"
+  s.add_development_dependency 'appraisal'
+  s.add_development_dependency 'pry-rails'
+  s.add_development_dependency 'rails-controller-testing'
+  s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'rubocop', '~> 0.61.0'
+  s.add_development_dependency 'shoulda-matchers', '~> 2.8'
+  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'timecop'
+  s.add_development_dependency 'webmock'
 
   s.required_ruby_version = '>= 2.1.0'
 end


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

Seems like a bunch of development dependencies had accrued in the `Gemfile` over time -- after some experimentation, it seems like only one was actually necessary (`jbuilder`) so I added a comment explaining why, and put all of the others in the `.gemspec`. (Actually, `selenium-webdriver` seemed entirely unused, so I ended up removing it.)

This results in tidier Appraisal-generated gemfiles too.

Again, development dependencies -- this shouldn't impact the actual release cut of the gem.