### PR TITLE
Add github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# How to Contribute
+
+We would love for you to contribute! Anything that benefits the majority of `test_track` users—from a documentation fix to an entirely new feature—is encouraged.
+
+Before diving in, [check our issue tracker](//github.com/Betterment/test_track_rails_client/issues) and consider creating a new issue to get early feedback on your proposed change.
+
+## Suggested Workflow
+
+* Fork the project and create a new branch for your contribution.
+* Write your contribution (and any applicable test coverage).
+* Make sure all tests pass (`bundle exec rake`).
+* Submit a pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Summary
+
+> Provide a general description of the code changes in your pull
+request... were there any bugs you had fixed? If so, mention them. If
+these bugs have open GitHub issues, be sure to tag them here as well,
+to keep the conversation linked together.
+
+### Other Information
+
+> If there's anything else that's important and relevant to your pull
+request, mention that information here. This could include
+benchmarks, or other information.
+
+> Thanks for contributing to TestTrack!
+
+/domain @Betterment/test_track_core
+/platform @Betterment/test_track_core

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 
+branches:
+  only:
+  - master
+
 rvm:
 - 2.5.7
 - 2.6.5


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

I pulled these from the main test_track repo. Figured they were useful here.

I'm also attempting to fix the wasteful and annoying duplicate travis builds. (I know, I should fork the repo 😳)