### PR TITLE
Unpin faraday dependency, support >= 1.0

### DIFF
--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'delayed_job', '~> 4.0'
   s.add_dependency 'delayed_job_active_record'
-  s.add_dependency "faraday", ">= 0.8", "< 1.0"
+  s.add_dependency "faraday", ">= 0.8"
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
   s.add_dependency 'multi_json', '~> 1.7'

--- a/vendor/gems/her/her.gemspec
+++ b/vendor/gems/her/her.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.5"
 
   s.add_runtime_dependency "activemodel", ">= 4.2.1"
-  s.add_runtime_dependency "faraday", ">= 0.8", "< 1.0"
+  s.add_runtime_dependency "faraday", ">= 0.8"
   s.add_runtime_dependency "multi_json", "~> 1.7"
 end


### PR DESCRIPTION
### Summary

I think this gem predates faraday 1.0 and we were simply being cautious, but now that 1.0 is out, it looks like we can unpin the version and all tests still pass.

### Other Information

I can confirm that faraday v1.3.0 is picked up by the lockfiles when bundle resolves dependencies. (I don't think there's a need to add an appraisal to test with an older faraday version, or anything like that.)

/domain @Betterment/test_track_core @RowanMcDonald 
/platform @Betterment/test_track_core @RowanMcDonald 
