### PR TITLE
Introduce public url var that's shared with browser client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Set up ENV vars in every environment:
 
 * `MIXPANEL_TOKEN` - By default, TestTrack reports to Mixpanel. If you're using a [custom analytics provider](#analytics) you can omit this.
 * `TEST_TRACK_API_URL` - Set this to the URL of your TestTrack instance with your app credentials, e.g. `http://[myapp]:[your new app password]@[your-app-domain]/`
+* `TEST_TRACK_PUBLIC_API_URL` - (optional) If public traffic to TestTrack should use a different host name, set this variable. By default this will use `TEST_TRACK_API_URL` without any credentials
 
   [your-app-domain] can be
   * `testtrack.test`

--- a/app/models/test_track/web_session.rb
+++ b/app/models/test_track/web_session.rb
@@ -25,7 +25,7 @@ class TestTrack::WebSession
 
   def state_hash
     {
-      url: TestTrack.url,
+      url: TestTrack.public_url,
       cookieDomain: cookie_domain,
       cookieName: visitor_cookie_name,
       splits: current_visitor.split_registry.to_hash,

--- a/lib/test_track.rb
+++ b/lib/test_track.rb
@@ -115,17 +115,21 @@ module TestTrack
     yield(ConfigUpdater.new)
   end
 
-  def url
+  def public_url
+    ENV['TEST_TRACK_PUBLIC_API_URL'] || _uncredentialed_private_url
+  end
+
+  def private_url
+    ENV['TEST_TRACK_API_URL']
+  end
+
+  def _uncredentialed_private_url
     return nil unless private_url
 
     full_uri = URI.parse(private_url)
     full_uri.user = nil
     full_uri.password = nil
     full_uri.to_s
-  end
-
-  def private_url
-    ENV['TEST_TRACK_API_URL']
   end
 
   def _build_timestamp

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "4.0.1" # rubocop:disable Style/MutableConstant
+  VERSION = "4.0.2" # rubocop:disable Style/MutableConstant
 end

--- a/spec/models/test_track/web_session_spec.rb
+++ b/spec/models/test_track/web_session_spec.rb
@@ -540,8 +540,18 @@ RSpec.describe TestTrack::WebSession do
       allow(split_registry).to receive(:experience_sampling_weight).and_return(sampling_weight)
     end
 
-    it "includes the test track URL" do
-      expect(subject.state_hash[:url]).to eq "http://testtrack.dev"
+    context 'when no public url is provided' do
+      it "defaults to the private test track URL" do
+        expect(subject.state_hash[:url]).to eq "http://testtrack.dev"
+      end
+    end
+
+    context 'when a public url is provided' do
+      it "uses the public test track URL" do
+        with_env TEST_TRACK_PUBLIC_API_URL: 'http://public.url.com' do
+          expect(subject.state_hash[:url]).to eq "http://public.url.com"
+        end
+      end
     end
 
     it "includes the cookie_domain" do

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -307,4 +307,22 @@ RSpec.describe TestTrack do
       end
     end
   end
+
+  describe '.public_url' do
+    context 'when TEST_TRACK_PUBLIC_API_URL is set' do
+      it 'returns it' do
+        with_env TEST_TRACK_PUBLIC_API_URL: 'http://public.url.com' do
+          expect(TestTrack.public_url).to eq 'http://public.url.com'
+        end
+      end
+    end
+
+    context 'when TEST_TRACK_PUBLIC_API_URL is not set' do
+      it 'returns private url with credentials removed' do
+        with_env TEST_TRACK_API_URL: 'http://user:pass@private.url.com' do
+          expect(TestTrack.public_url).to eq 'http://private.url.com'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Summary

For deployments where public traffic should run over a different network than service API calls, we're providing another environment variable that allows you to configure the publicly accessible TestTrack url. Now you can provide `TEST_TRACK_PUBLIC_API_URL` which will be passed along to the javascript client. By default, publicly accessible traffic will continue to use `TEST_TRACK_API_URL`.

/domain @Betterment/test_track_core
/no-platform 
