### PR TITLE
Update public_suffix in gemspec

### DIFF
--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "5.0.0" # rubocop:disable Style/MutableConstant
+  VERSION = "5.0.1" # rubocop:disable Style/MutableConstant
 end

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
   s.add_dependency 'multi_json', '~> 1.7'
-  s.add_dependency 'public_suffix', '>= 2.0.0', '<= 3.0.0'
+  s.add_dependency 'public_suffix', '~> 4.0.6'
   s.add_dependency 'railties', '>= 5.1'
   s.add_dependency 'request_store', '~> 1.3'
   s.add_dependency 'sprockets-rails'

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'mixpanel-ruby', '~> 1.4'
   s.add_dependency 'multi_json', '~> 1.7'
-  s.add_dependency 'public_suffix', '~> 4.0.6'
+  s.add_dependency 'public_suffix', '>= 2.0.0'
   s.add_dependency 'railties', '>= 5.1'
   s.add_dependency 'request_store', '~> 1.3'
   s.add_dependency 'sprockets-rails'


### PR DESCRIPTION
### Summary

Updating the `public_suffix` in the gemspec and incrementing version number (patch release) to 5.0.1 

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core @smudge
