### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

GH Actions no longer supports 16.04, so they spin forever.