### PR TITLE
Keep decided/100% variants at 100% in offline registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,19 @@ def notify(message)
 
 ## Upgrading
 
+### From 5.0 to 6.0
+
+* The offline split registry (used in tests, etc) will now favor variants with
+  weights of 100% when generating deterministic weightings. If no variant has a
+  weight of 100%, then it will fall back on the previous behavior of favoring
+  the variant with the lowest alphanumerically-sorted name (conventionally
+  "false" and "control").
+
+  This means that, when deciding a split via a migration (and/or updating a new
+  variant to 100% in the schema), tests that assumed the previous variant may
+  begin to fail and will require additional code cleanup (or must be explicitly
+  stubbed to use the previous variant).
+
 ### From 3.0 to 4.0
 
 * The contract of custom analytics plugins has changed. Instead of

--- a/README.md
+++ b/README.md
@@ -403,6 +403,14 @@ def notify(message)
   begin to fail and will require additional code cleanup (or must be explicitly
   stubbed to use the previous variant).
 
+### From 4.0 to 5.0
+
+* The direct dependency on the `delayed_job_active_record` gem has been removed,
+  and background jobs now depend on the `ActiveJob` framework. When upgrading,
+  ensure that your application [specifies a
+  backend](https://guides.rubyonrails.org/active_job_basics.html#setting-the-backend)
+  (e.g. `config.active_job.queue_adapter = :delayed_job`).
+
 ### From 3.0 to 4.0
 
 * The contract of custom analytics plugins has changed. Instead of

--- a/app/models/test_track/fake/split_registry.rb
+++ b/app/models/test_track/fake/split_registry.rb
@@ -67,7 +67,7 @@ class TestTrack::Fake::SplitRegistry
 
   def split_registry_with_deterministic_weights
     splits = split_hash.each_with_object({}) do |(split_name, weighting_registry), result|
-      default_variant = weighting_registry.keys.min
+      default_variant = weighting_registry.invert[100] || weighting_registry.keys.min
 
       adjusted_weights = { default_variant => 100 }
       weighting_registry.except(default_variant).each_key do |variant|

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "5.0.1" # rubocop:disable Style/MutableConstant
+  VERSION = "6.0.0" # rubocop:disable Style/MutableConstant
 end

--- a/spec/dummy/db/test_track_schema.yml
+++ b/spec/dummy/db/test_track_schema.yml
@@ -7,3 +7,6 @@ splits:
     blue: 34
     red: 33
     white: 33
+  decided_split:
+    control: 0
+    treatment: 100

--- a/spec/dummy/testtrack/schema.yml
+++ b/spec/dummy/testtrack/schema.yml
@@ -10,3 +10,7 @@ splits:
   weights:
     "false": 50
     "true": 50
+- name: decided_split
+  weights:
+    control: 0
+    treatment: 100

--- a/spec/models/test_track/fake/split_registry_spec.rb
+++ b/spec/models/test_track/fake/split_registry_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
                   red: 0
                 },
                 feature_gate: false
+              },
+              decided_split: {
+                weights: {
+                  control: 0,
+                  treatment: 100
+                },
+                feature_gate: false
               }
             },
             experience_sampling_weight: 1
@@ -35,7 +42,8 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
       it 'returns an array of splits with deterministic weights' do
         expect(subject.splits).to eq [
           TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 100, 'red' => 0, 'white' => 0),
-          TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 100, 'true' => 0)
+          TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 100, 'true' => 0),
+          TestTrack::Fake::SplitRegistry::Split.new('decided_split', 'control' => 0, 'treatment' => 100)
         ]
       end
     end
@@ -68,6 +76,13 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
                   red: 0
                 },
                 feature_gate: false
+              },
+              decided_split: {
+                weights: {
+                  control: 0,
+                  treatment: 100
+                },
+                feature_gate: false
               }
             },
             experience_sampling_weight: 1
@@ -80,7 +95,8 @@ RSpec.describe TestTrack::Fake::SplitRegistry do
       it 'returns an array of splits with deterministic weights' do
         expect(subject.splits).to eq [
           TestTrack::Fake::SplitRegistry::Split.new('buy_one_get_one_promotion_enabled', 'false' => 100, 'true' => 0),
-          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 100, 'white' => 0, 'red' => 0)
+          TestTrack::Fake::SplitRegistry::Split.new('banner_color', 'blue' => 100, 'white' => 0, 'red' => 0),
+          TestTrack::Fake::SplitRegistry::Split.new('decided_split', 'control' => 0, 'treatment' => 100)
         ]
       end
     end

--- a/spec/models/test_track/fake/visitor_spec.rb
+++ b/spec/models/test_track/fake/visitor_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe TestTrack::Fake::Visitor do
       it 'returns an array of assignments' do
         expect(subject.assignments).to match_array [
           TestTrack::Fake::Visitor::Assignment.new('buy_one_get_one_promotion_enabled', 'false', false, "the_context"),
-          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context")
+          TestTrack::Fake::Visitor::Assignment.new('banner_color', 'blue', false, "the_context"),
+          TestTrack::Fake::Visitor::Assignment.new('decided_split', 'treatment', false, "the_context")
         ]
       end
     end


### PR DESCRIPTION
### Summary

I've added this to the README, which should explain this change:

> The offline split registry (used in tests, etc) will now favor variants with weights of 100% when generating deterministic weightings. If no variant has a weight of 100%, then it will fall back on the previous behavior of favoring the variant with the lowest alphanumerically-sorted name (conventionally “false” and “control”).
> 
> This means that, when deciding a split via a migration (and/or updating a new variant to 100% in the schema), tests that assumed the previous variant may begin to fail and will require additional code cleanup (or must be explicitly stubbed to use the previous variant).

Because it's technically a breaking change, I've updated the version to `6.0.0`.

### Other Information

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core
/cc @willlockwood