### PR TITLE
Set build timestamp initializer order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test_track_rails_client (7.1.0)
+    test_track_rails_client (7.1.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)
@@ -239,6 +239,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22

--- a/config/initializers/set_build_timestamp.rb
+++ b/config/initializers/set_build_timestamp.rb
@@ -1,1 +1,0 @@
-TestTrack.set_build_timestamp! unless ENV['SKIP_TESTTRACK_SET_BUILD_TIMESTAMP'] == '1'

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (7.1.0)
+    test_track_rails_client (7.1.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)
@@ -207,6 +207,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (7.1.0)
+    test_track_rails_client (7.1.1)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)
@@ -207,6 +207,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22

--- a/lib/test_track_rails_client/engine.rb
+++ b/lib/test_track_rails_client/engine.rb
@@ -9,5 +9,9 @@ module TestTrackRailsClient
     config.generators do |g|
       g.test_framework :rspec
     end
+
+    initializer after: 'active_support.initialize_time_zone' do
+      TestTrack.set_build_timestamp! unless ENV['SKIP_TESTTRACK_SET_BUILD_TIMESTAMP'] == '1'
+    end
   end
 end

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "7.1.0".freeze
+  VERSION = "7.1.1".freeze
 end


### PR DESCRIPTION
### Summary

I noticed that some recent changes to my load order in a consuming app resulted in this initializer running too soon, before `Time.zone` was defined by Rails. This change forces it to always run _after_ `'active_support.initialize_time_zone'`.

/domain @Betterment/test_track_core
/no-platform
