### PR TITLE
Prohibit feature flag

### DIFF
--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -15,6 +15,12 @@ module TestTrack::Controller
         raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
       end
     end
+
+    def prohibit_feature_flag(feature_flag, *args)
+      before_action(*args) do
+        raise ActionController::RoutingError, 'Not Found' if test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
### Summary
Adds a `prohibit_feature_flag` method that acts as the opposite of `require_feature_flag`. 
Example use case: the team is working on rolling out 2fa for a new app. In phase 1, you allow a user to disable their 2fa configuration. In phase 2, you want to require 2fa configuration behind a new feature flag. So you have a `disable_2fa_controller.rb` where you want to `require_feature_flag 2fa_enabled`, but `prohibit_feature_flag 2fa_required_enabled`, until the time comes where you can safely delete the entire controller at the end of your project.

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core
