### PR TITLE
fix: Prevent multiple identical instantiations of application identity within calls to `TestTrack.app_ab`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test_track_rails_client (7.1.1)
+    test_track_rails_client (7.1.2)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -12,7 +12,7 @@ class TestTrack::ApplicationIdentity
   end
 
   def identity
-    @identity = @identity&.app_name == app_name ? @identity : Identity.new(app_name)
+    @identity ||= Identity.new(app_name)
   end
 
   class Identity
@@ -23,6 +23,8 @@ class TestTrack::ApplicationIdentity
     def initialize(app_name)
       @app_name = app_name
     end
+
+    private
 
     attr_reader :app_name
   end

--- a/app/models/test_track/application_identity.rb
+++ b/app/models/test_track/application_identity.rb
@@ -12,7 +12,7 @@ class TestTrack::ApplicationIdentity
   end
 
   def identity
-    Identity.new(app_name)
+    @identity = @identity&.app_name == app_name ? @identity : Identity.new(app_name)
   end
 
   class Identity
@@ -23,8 +23,6 @@ class TestTrack::ApplicationIdentity
     def initialize(app_name)
       @app_name = app_name
     end
-
-    private
 
     attr_reader :app_name
   end

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (7.1.1)
+    test_track_rails_client (7.1.2)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (7.1.1)
+    test_track_rails_client (7.1.2)
       activejob (>= 6.0)
       activemodel (>= 6.0)
       faraday (>= 0.8)

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "7.1.1".freeze
+  VERSION = "7.1.2".freeze
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,5 +56,7 @@ RSpec.configure do |config|
   config.before(:each) do
     clear_enqueued_jobs
     clear_performed_jobs
+
+    TestTrack::ApplicationIdentity.instance.tap { |i| i.remove_instance_variable(:@identity) if i.instance_variable_defined?(:@identity) }
   end
 end

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -163,6 +163,22 @@ RSpec.describe TestTrack do
           expect(TestTrack.app_ab(:dummy_feature, context: 'test_context')).to eq false
         end
       end
+
+      context "when called twice" do
+        let(:identity) { TestTrack::ApplicationIdentity.instance }
+
+        before do
+          stub_test_track_assignments(dummy_feature: 'false')
+          allow(identity.instance_variable_get(:@identity)).to receive(:test_track_ab).and_call_original
+        end
+
+        it "uses the same instance of the ApplicationIdentity for each call" do
+          TestTrack.app_ab(:dummy_feature, context: 'test_context')
+          TestTrack.app_ab(:dummy_feature, context: 'test_context')
+
+          expect(identity.instance_variable_get(:@identity)).to have_received(:test_track_ab).twice
+        end
+      end
     end
 
     context "when app_name is not specified" do

--- a/spec/test_track_spec.rb
+++ b/spec/test_track_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe TestTrack do
 
         before do
           stub_test_track_assignments(dummy_feature: 'false')
-          allow(identity.instance_variable_get(:@identity)).to receive(:test_track_ab).and_call_original
+          allow(identity.send(:identity)).to receive(:test_track_ab).and_call_original
         end
 
         it "uses the same instance of the ApplicationIdentity for each call" do


### PR DESCRIPTION
### Summary

Earlier I noticed that we were hitting N+1s on calls to `TestTrack.app_ab` for the application visitor identity, the main fix for which is to memoize the instance of `Identity` we use for calls to `TestTrack.app_ab`. So, just adding in some logic that memoizes the identity across multiple calls (given that the app name doesn't change between calls).

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core
