### PR TITLE
Extract method for feature flag check

### DIFF
--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -12,12 +12,16 @@ module TestTrack::Controller
   class_methods do
     def require_feature_flag(feature_flag, *args)
       before_action(*args) do
-        raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+        raise ActionController::RoutingError, 'Not Found' unless feature_flagged?(feature_flag)
       end
     end
   end
 
   private
+
+  def feature_flagged?(feature_flag)
+    test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+  end
 
   def test_track_session
     @test_track_session ||= TestTrack::WebSession.new(self)


### PR DESCRIPTION
While working on a controller we wanted a fallback behavior where we could check another related association for a test track assignment if the visitor did not have direct access.

With this in place a controller can override the check when needed without completely replacing the before_action behavior

```
def feature_flagged?(feature_flag)
  super || current_user.organization.test_track_ab(feature_flag, context: self.class.name.underscore)
end
```

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core
