### PR TITLE
Make sprockets-rails an optional dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test_track_rails_client (8.0.0)
+    test_track_rails_client (8.1.0)
       activejob (>= 7.0, < 8.1)
       activemodel (>= 7.0, < 8.1)
       faraday (>= 0.8)
@@ -11,7 +11,6 @@ PATH
       public_suffix (>= 2.0.0)
       railties (>= 7.0, < 8.1)
       request_store (~> 1.3)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -290,6 +289,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (>= 2.8)
   simplecov
+  sprockets-rails
   test_track_rails_client!
   timecop
   webmock

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.0.0)
+    test_track_rails_client (8.1.0)
       activejob (>= 7.0, < 8.1)
       activemodel (>= 7.0, < 8.1)
       faraday (>= 0.8)
@@ -11,7 +11,6 @@ PATH
       public_suffix (>= 2.0.0)
       railties (>= 7.0, < 8.1)
       request_store (~> 1.3)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -263,6 +262,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (>= 2.8)
   simplecov
+  sprockets-rails
   test_track_rails_client!
   timecop
   webmock

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.0.0)
+    test_track_rails_client (8.1.0)
       activejob (>= 7.0, < 8.1)
       activemodel (>= 7.0, < 8.1)
       faraday (>= 0.8)
@@ -11,7 +11,6 @@ PATH
       public_suffix (>= 2.0.0)
       railties (>= 7.0, < 8.1)
       request_store (~> 1.3)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -303,6 +302,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (>= 2.8)
   simplecov
+  sprockets-rails
   test_track_rails_client!
   timecop
   webmock

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.0.0)
+    test_track_rails_client (8.1.0)
       activejob (>= 7.0, < 8.1)
       activemodel (>= 7.0, < 8.1)
       faraday (>= 0.8)
@@ -11,7 +11,6 @@ PATH
       public_suffix (>= 2.0.0)
       railties (>= 7.0, < 8.1)
       request_store (~> 1.3)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -303,6 +302,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (>= 2.8)
   simplecov
+  sprockets-rails
   test_track_rails_client!
   timecop
   webmock

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.0.0)
+    test_track_rails_client (8.1.0)
       activejob (>= 7.0, < 8.1)
       activemodel (>= 7.0, < 8.1)
       faraday (>= 0.8)
@@ -11,7 +11,6 @@ PATH
       public_suffix (>= 2.0.0)
       railties (>= 7.0, < 8.1)
       request_store (~> 1.3)
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -304,6 +303,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers (>= 2.8)
   simplecov
+  sprockets-rails
   test_track_rails_client!
   timecop
   webmock

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "8.0.0".freeze
+  VERSION = "8.1.0".freeze
 end

--- a/test_track_rails_client.gemspec
+++ b/test_track_rails_client.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'public_suffix', '>= 2.0.0'
   s.add_dependency 'railties', rails_constraints
   s.add_dependency 'request_store', '~> 1.3'
-  s.add_dependency 'sprockets-rails'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'betterlint'
@@ -36,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers', '>= 2.8'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sprockets-rails'
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'zeitwerk', '< 2.7'


### PR DESCRIPTION
### Summary

This gem should not require downstream applications to use sprockets. This gem does provide a JavaScript asset under `app/assets/javascript` and it does enhance the `assets:precompile` with additional functionality, but these things don't necessarily depend on `sprockets-rails`, so it `sprockets-rails` is really more of an optional dependency.

The dummy app does currently depend on `sprockets-rails`, so this should be development dependency.

### Other Information

> If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

> Thanks for contributing to TestTrack!

/domain @Betterment/test_track_core
/platform @Betterment/test_track_core
