### PR TITLE
chore: Replace `/domain` & `/platform` in PR template with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Betterment/test_track_core

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,3 @@ request, mention that information here. This could include
 benchmarks, or other information.
 
 > Thanks for contributing to TestTrack!
-
-/domain @Betterment/test_track_core
-/platform @Betterment/test_track_core


### PR DESCRIPTION
This removes `/domain` and `/platform` declarations from the PR template and replaces them with a default CODEOWNERS-driven review request.

/no-platform