### PR TITLE
feat: add reject_feature_flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    test_track_rails_client (8.4.0)
+    test_track_rails_client (8.5.0)
       activejob (>= 7.2, < 8.1)
       activemodel (>= 7.2, < 8.1)
       faraday (>= 0.8)

--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -10,15 +10,10 @@ module TestTrack::Controller
   end
 
   class_methods do
-    def require_feature_flag(feature_flag, *args, enabled: true)
-      before_action(*args) do
-        flag_value = test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
-
-        if enabled
-          raise ActionController::RoutingError, 'Not Found' unless flag_value
-        else
-          raise ActionController::RoutingError, 'Not Found' if flag_value
-        end
+    def require_feature_flag(feature_flag, *args, required_variant: nil, **kwargs)
+      before_action(*args, **kwargs) do
+        raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, true_variant: required_variant,
+                                                                                                     context: self.class.name.underscore)
       end
     end
   end

--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -10,10 +10,15 @@ module TestTrack::Controller
   end
 
   class_methods do
-    def require_feature_flag(feature_flag, *args, required_variant: nil, **kwargs)
-      before_action(*args, **kwargs) do
-        raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, true_variant: required_variant,
-                                                                                                     context: self.class.name.underscore)
+    def require_feature_flag(feature_flag, *args)
+      before_action(*args) do
+        raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+      end
+    end
+
+    def reject_feature_flag(feature_flag, *args)
+      before_action(*args) do
+        raise ActionController::RoutingError, 'Not Found' if test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
       end
     end
   end

--- a/app/controllers/concerns/test_track/controller.rb
+++ b/app/controllers/concerns/test_track/controller.rb
@@ -10,9 +10,15 @@ module TestTrack::Controller
   end
 
   class_methods do
-    def require_feature_flag(feature_flag, *args)
+    def require_feature_flag(feature_flag, *args, enabled: true)
       before_action(*args) do
-        raise ActionController::RoutingError, 'Not Found' unless test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+        flag_value = test_track_visitor.ab(feature_flag, context: self.class.name.underscore)
+
+        if enabled
+          raise ActionController::RoutingError, 'Not Found' unless flag_value
+        else
+          raise ActionController::RoutingError, 'Not Found' if flag_value
+        end
       end
     end
   end

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.4.0)
+    test_track_rails_client (8.5.0)
       activejob (>= 7.2, < 8.1)
       activemodel (>= 7.2, < 8.1)
       faraday (>= 0.8)

--- a/gemfiles/rails_8_0.gemfile.lock
+++ b/gemfiles/rails_8_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    test_track_rails_client (8.4.0)
+    test_track_rails_client (8.5.0)
       activejob (>= 7.2, < 8.1)
       activemodel (>= 7.2, < 8.1)
       faraday (>= 0.8)

--- a/lib/test_track_rails_client/version.rb
+++ b/lib/test_track_rails_client/version.rb
@@ -1,3 +1,3 @@
 module TestTrackRailsClient
-  VERSION = "8.4.0".freeze
+  VERSION = "8.5.0".freeze
 end

--- a/spec/controllers/concerns/test_track/test_trackable_controller_spec.rb
+++ b/spec/controllers/concerns/test_track/test_trackable_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe TestTrack::Controller do
 
   controller(ApplicationController) do
     include mixin
-    require_feature_flag :cool_feature_enabled
 
     self.test_track_identity = :current_clown
 
@@ -115,27 +114,15 @@ RSpec.describe TestTrack::Controller do
     expect(RequestStore).to have_received(:[]=).with(:test_track_web_session, instance_of(TestTrack::WebSession))
   end
 
-  it "raises a RoutingError when a feature flag is required and the ab value is false" do
-    allow(TestTrack::VisitorDsl).to receive(:new).and_return(
-      instance_double(TestTrack::VisitorDsl, ab: false)
-    )
-    expect { get :index }.to raise_error ActionController::RoutingError, 'Not Found'
-  end
-
-  it "passes the context to the ab call" do
-    get :index
-    expect(visitor_dsl).to have_received(:ab).with(:cool_feature_enabled, true_variant: nil, context: 'anonymous_controller')
-  end
-
-  context "with required_variant" do
+  context "require_feature_flag" do
     controller(ApplicationController) do
-      include TestTrack::Controller
-      require_feature_flag :experiment_split, required_variant: 'treatment'
+      include mixin
+      require_feature_flag :cool_feature_enabled
 
       self.test_track_identity = :current_clown
 
       def index
-        render json: { status: 'ok' }
+        head :no_content
       end
 
       private
@@ -145,31 +132,53 @@ RSpec.describe TestTrack::Controller do
 
     let(:visitor_dsl) { instance_double(TestTrack::VisitorDsl, ab: true) }
 
-    before do
-      allow(TestTrack::Remote::SplitRegistry).to receive(:to_hash).and_return(split_registry)
-      allow(TestTrack::Remote::Visitor).to receive(:fake_instance_attributes).and_return(remote_visitor)
-      allow(TestTrack::VisitorDsl).to receive(:new).and_return(visitor_dsl)
-      allow(RequestStore).to receive(:[]=).and_return(visitor_dsl)
-    end
-
-    it "passes the required_variant to the ab call as true_variant" do
-      get :index
-      expect(visitor_dsl).to have_received(:ab).with(:experiment_split, true_variant: 'treatment', context: 'anonymous_controller')
-    end
-
-    it "allows access when the variant matches" do
-      allow(TestTrack::VisitorDsl).to receive(:new).and_return(
-        instance_double(TestTrack::VisitorDsl, ab: true)
-      )
-      get :index
-      expect(response).to have_http_status(:ok)
-    end
-
-    it "raises a RoutingError when the variant does not match" do
+    it "raises a RoutingError when the ab value is false" do
       allow(TestTrack::VisitorDsl).to receive(:new).and_return(
         instance_double(TestTrack::VisitorDsl, ab: false)
       )
       expect { get :index }.to raise_error ActionController::RoutingError, 'Not Found'
+    end
+
+    it "allows access when the ab value is true" do
+      allow(TestTrack::VisitorDsl).to receive(:new).and_return(
+        instance_double(TestTrack::VisitorDsl, ab: true)
+      )
+      get :index
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  context "reject_feature_flag" do
+    controller(ApplicationController) do
+      include mixin
+      reject_feature_flag :cool_feature_enabled
+
+      self.test_track_identity = :current_clown
+
+      def index
+        head :no_content
+      end
+
+      private
+
+      def current_clown; end
+    end
+
+    let(:visitor_dsl) { instance_double(TestTrack::VisitorDsl, ab: false) }
+
+    it "raises a RoutingError when the ab value is true" do
+      allow(TestTrack::VisitorDsl).to receive(:new).and_return(
+        instance_double(TestTrack::VisitorDsl, ab: true)
+      )
+      expect { get :index }.to raise_error ActionController::RoutingError, 'Not Found'
+    end
+
+    it "allows access when the ab value is false" do
+      allow(TestTrack::VisitorDsl).to receive(:new).and_return(
+        instance_double(TestTrack::VisitorDsl, ab: false)
+      )
+      get :index
+      expect(response).to have_http_status(:no_content)
     end
   end
 end


### PR DESCRIPTION
### Summary

1. Added `reject_feature_flag` method to complement `require_feature_flag`:
  - `require_feature_flag` - returns 404 if flag is **false** (blocks when disabled)
  - `reject_feature_flag` - returns 404 if flag is **true** (blocks when enabled)

2. Added spec tests for `reject_feature_flag` and organized contexts:
  - General `TestTrack::Controller` functionality tests
  - Dedicated context for `require_feature_flag` tests
  - Dedicated context for `reject_feature_flag` tests